### PR TITLE
Shellcheck fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.8
+current_version = 0.0.9
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ cfn/lint: | guard/program/cfn-lint
 	$(FIND_CFN) | $(XARGS) cfn-lint -t {}
 
 ## Runs eclint against the project
+eclint/lint: PROJECT_ROOT ?= .
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: ECLINT_PREFIX ?= git ls-files -z | xargs -0
 eclint/lint:
@@ -216,7 +217,7 @@ hcl/format: | guard/program/terraform hcl/validate
 	$(FIND_HCL) | $(XARGS) cat {} | terraform fmt -
 	@ echo "[$@]: Successfully formatted hcl files!"
 
-sh/%: FIND_SH := find . $(FIND_EXCLUDES) -name '*.sh' -type f -print0
+sh/%: FIND_SH := find . $(FIND_EXCLUDES) -name '*.sh' -type f
 ## Lints bash script files
 sh/lint: | guard/program/shellcheck
 	@ echo "[$@]: Linting shell scripts..."

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ bats/test: | guard/program/bats
 
 project/validate:
 	@ echo "[$@]: Ensuring the target test folder is not empty"
-	[ "$$(ls -A $(PROJECT_ROOT))" ] && (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
+	[ "$$(ls -A $(PROJECT_ROOT))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
 install: terraform/install shellcheck/install terraform-docs/install bats/install black/install eclint/install yamllint/install cfn-lint/install yq/install

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ green = $(shell echo -e '\x1b[32;01m$1\x1b[0m')
 yellow = $(shell echo -e '\x1b[33;01m$1\x1b[0m')
 red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
+PROJECT_ROOT ?= .
+
 default:: $(DEFAULT_HELP_TARGET)
 	@exit 0
 
@@ -166,7 +168,6 @@ cfn/lint: | guard/program/cfn-lint
 	$(FIND_CFN) | $(XARGS) cfn-lint -t {}
 
 ## Runs eclint against the project
-eclint/lint: PROJECT_ROOT ?= .
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: ECLINT_PREFIX ?= git ls-files -z | xargs -0
 eclint/lint:
@@ -300,6 +301,11 @@ bats/test: | guard/program/bats
 	cd tests/make && bats -r *.bats
 	@ echo "[$@]: Completed successfully!"
 
+project/validate:
+	@ echo "[$@]: Ensuring the target test folder is not empty"
+	[ "$$(ls -A $(PROJECT_ROOT))" ] && (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
+	@ echo "[$@]: Target test folder validation successful"
+
 install: terraform/install shellcheck/install terraform-docs/install bats/install black/install eclint/install yamllint/install cfn-lint/install yq/install
 
-lint: terraform/lint sh/lint json/lint docs/lint python/lint eclint/lint cfn/lint hcl/lint
+lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint eclint/lint cfn/lint hcl/lint

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -62,6 +62,7 @@ docker/run: docker/build
 	-e AWS_PROFILE=$(AWS_PROFILE) \
 	-e AWS_SHARED_CREDENTIALS_FILE=/.aws/credentials \
 	-e INCLUDE=/ci-harness/$(PROJECT_NAME)/Makefile \
+	-e PROJECT_ROOT=/ci-harness/$(PROJECT_NAME) \
 	$(IMAGE_NAME) $(target)
 
 ## Cleans local docker environment

--- a/tests/make/project_validate_failure.bats
+++ b/tests/make/project_validate_failure.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/project_validate_failure"
+
+# generate a folder without content
+function setup() {
+rm -rf "$TEST_DIR"
+mkdir "$TEST_DIR"
+
+}
+
+@test "project/validate: success" {
+  run make project/validate PROJECT_ROOT="$TEST_DIR"
+  [ "$status" -eq 2 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}

--- a/tests/make/project_validate_success.bats
+++ b/tests/make/project_validate_success.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/project_validate_success"
+
+# generate folders with content
+function setup() {
+rm -rf "$TEST_DIR"
+working_dirs=("$TEST_DIR" "$TEST_DIR/nested")
+for working_dir in "${working_dirs[@]}"
+do
+
+  mkdir -p "$working_dir"
+  cat > "$working_dir/test.py" <<"EOF"
+
+print("foo")
+EOF
+done
+
+}
+
+@test "project/validate: success" {
+  run make project/validate
+  [ "$status" -eq 0 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}


### PR DESCRIPTION
- updates `sh/lint` target
- adds better handling of the` PROJECT_ROOT` env var
- adds `project/validate` target 

re `project/validate` - was running into a weird permissions thing with windows + wsl + docker where docker would create the specified bind mounts but they would be empty container side. Hopefully this new target will avoid excessive head scratching should anyone else have this issue.