### PR TITLE
eclint/lint update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.0.10
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       install:
         - npm install -g eclint
         - eclint --version
-      script: eclint check
+      script: make eclint/lint
     - stage: lint
       name: Shell Script Syntax Verification
       script: make sh/lint

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ cfn/lint: | guard/program/cfn-lint
 
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
-eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell git diff-index --quiet HEAD -- || echo "true")
+eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell git status -s || echo "true")
 eclint/lint: ECLINT_PREFIX ?= git ls-files -z
 eclint/lint:
 	@ echo "[$@]: Running eclint..."

--- a/Makefile
+++ b/Makefile
@@ -170,12 +170,12 @@ cfn/lint: | guard/program/cfn-lint
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell git status -s || echo "true")
-eclint/lint: ECLINT_PREFIX ?= git ls-files -z
+eclint/lint: ECLINT_FILES ?= git ls-files -z
 eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \
 	[ -z "$(HAS_UNTRACKED_CHANGES)" ] || (echo "untracked changes detected!" && exit 1)
-	$(ECLINT_PREFIX) | $(XARGS) --null bash -c 'if ! [[ "{}" == *".bats"* ]]; then eclint check {}; fi'
+	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
 python/%: FIND_PYTHON := find . $(FIND_EXCLUDES) -name '*.py' -type f

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,12 @@ bats/install:
 	@ echo "[$@]: Completed successfully!"
 
 bats/test: | guard/program/bats
+bats/test: GIT_USERNAME ?= $(shell git config user.name)
+bats/test: GIT_EMAIL ?= $(shell git config user.email)
+bats/test:
 	@ echo "[$@]: Starting make target unit tests"
+	[ -n "$(GIT_USERNAME)" ] && echo "git username set" || git config user.name "bats"
+	[ -n "$(GIT_EMAIL)" ] && echo "git email set" || git config user.email "bats@test.com"
 	cd tests/make && bats -r *.bats
 	@ echo "[$@]: Completed successfully!"
 

--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,8 @@ eclint/lint: ECLINT_PREFIX ?= git ls-files -z
 eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \
-	[ -z "$(HAS_UNTRACKED_CHANGES)" ] && \
-	($(ECLINT_PREFIX) | $(XARGS) --null bash -c 'if ! [[ "{}" == *".bats"* ]]; then eclint check {}; fi') || \
-	(echo "untracked changes detected!" && exit 1)
+	[ -z "$(HAS_UNTRACKED_CHANGES)" ] || (echo "untracked changes detected!" && exit 1)
+	$(ECLINT_PREFIX) | $(XARGS) --null bash -c 'if ! [[ "{}" == *".bats"* ]]; then eclint check {}; fi'
 	@ echo "[$@]: Project PASSED eclint test!"
 
 python/%: FIND_PYTHON := find . $(FIND_EXCLUDES) -name '*.py' -type f

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -44,7 +44,8 @@ docker/build: IMAGE_ID ?= $(shell $(GET_IMAGE_ID))
 docker/build: DOCKER_BUILDKIT ?= $(shell [ -z $(TRAVIS) ] && echo "DOCKER_BUILDKIT=1" || echo "DOCKER_BUILDKIT=0";)
 docker/build:
 	@echo "[$@]: building docker image"
-	[ -z $(IMAGE_ID) ] && $(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) -f $(PROJECT_ROOT)Dockerfile . || echo "Image present"
+	[ -n "$(IMAGE_ID)" ] && echo "Image present" || \
+	$(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) -f $(PROJECT_ROOT)Dockerfile .
 	@echo "[$@]: Docker image build complete"
 
 # Adds the current Makefile working directory as a bind mount

--- a/tests/make/eclint_lint_success.bats
+++ b/tests/make/eclint_lint_success.bats
@@ -13,6 +13,7 @@ do
   cat > "$working_dir/Makefile" <<"EOF"
 echo "foo"
 EOF
+
 done
 
 }

--- a/tests/make/eclint_lint_success.bats
+++ b/tests/make/eclint_lint_success.bats
@@ -16,6 +16,9 @@ EOF
 
 done
 
+git add "$TEST_DIR/."
+git commit -m 'eclint success testing'
+
 }
 
 @test "eclint/lint: success" {
@@ -24,5 +27,6 @@ done
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/eclint_unstaged_commits_failure.bats
+++ b/tests/make/eclint_unstaged_commits_failure.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-# NOTE: edit this file in an editor not configured to auto remediate
-# required editor config changes (vim, nano, etc)
-
 TEST_DIR="$(pwd)/eclint_lint_failure"
 
 # generate a test terraform project with a nested project
@@ -22,17 +19,13 @@ trailing whitespace test
 EOF
 done
 
-git add "$TEST_DIR/."
-git commit -m 'eclint failure testing'
-
 }
 
-@test "eclint/lint: failure" {
+@test "eclint/lint: unstaged commit failure" {
   run make eclint/lint
   [ "$status" -eq 2 ]
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }


### PR DESCRIPTION
- adds logic to `eclint/lint` make target to ensure there are no unstaged commits. `git ls-files` only provides results for files that are in the project's commit history
- ensures that `eclint/lint` ignores `*.bats` files
- updates the `eclint/lint` bats tests

- updates `docker/run` target to utilize the `-n` operator as opposed to the `-z` operator