### PR TITLE
Bumps version to 0.0.11

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.10
+current_version = 0.0.11
 commit = True
 message = Bumps version to {new_version}
 tag = False


### PR DESCRIPTION
Docker hub's regex for release on tag was configured to update on single digit semver string (0.0.0 vs 00.00.00). 

The build logic has been updated, but the only way to manually re-run the build on tag is to either remove/re-add the tag or to add a new tag.