### PR TITLE
Project root fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.11
+current_version = 0.0.12
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ cfn/lint: | guard/program/cfn-lint
 
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
-eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell git status -s || echo "true")
+eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell cd $(PROJECT_ROOT) && git status -s || echo "true")
 eclint/lint: ECLINT_FILES ?= git ls-files -z
 eclint/lint:
 	@ echo "[$@]: Running eclint..."

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -70,4 +70,5 @@ docker/run: docker/build
 docker/clean:
 	@echo "[$@]: Cleaning docker environment"
 	docker image prune -a -f
+	docker system prune -a -f
 	@echo "[$@]: cleanup successful"

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -5,9 +5,8 @@ export TARDIGRADE_CI_BRANCH ?= master
 export TARDIGRADE_CI_PATH ?= $(shell until [ -d "$(TARDIGRADE_CI_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(TARDIGRADE_CI_PROJECT)
 
 export MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-export PROJECT_ROOT := $(dir $(MAKEFILE_PATH))
+export PROJECT_ROOT ?= $(dir $(MAKEFILE_PATH))
 export PROJECT_NAME := $(notdir $(patsubst %/,%,$(PROJECT_ROOT)))
-
 
 -include $(TARDIGRADE_CI_PATH)/bootstrap/Makefile
 


### PR DESCRIPTION
- `eclint/lint`:  ensures `git status -s` runs from the project root directory
- `docker/clean`: adds `docker system prune`
- `Makefile.bootstrap`: ensures `PROJECT_ROOT` env var takes precedence 