### PR TITLE
Eclint fix round 2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.12
+current_version = 0.0.13
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \
 	[ -z "$(HAS_UNTRACKED_CHANGES)" ] || (echo "untracked changes detected!" && exit 1)
+	cd $(PROJECT_ROOT) && \
 	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 


### PR DESCRIPTION
Most of our other targets are using `find` to run the target's base tool over the target project recursively. Since eclint doesn't have a dot ignore file it has to be fed results from `git ls` which, previously, was being run from the top level directory of tardigrade-ci, _not_ from the root of the project we want to actually lint. This should fix that.

a little more context. 

before: 
```
[eclint/lint]: Running eclint...
cd /ci-harness/utils && \
[ -z "" ] || (echo "untracked changes detected!" && exit 1)
git ls-files -z | grep -zv ".bats" | xargs -0 -I {} echo {}
.bumpversion.cfg
.dependabot/config.yml
.dummy_include
.editorconfig
.gitignore
.mergify.yml
.travis.yml
.yamllint.yml
CHANGELOG.md
Dockerfile
LICENSE
Makefile
README.md
bootstrap/Makefile
bootstrap/Makefile.bootstrap
bootstrap/bin/install.sh
tests/make/Makefile
tests/terraform/example_testcase/main.tf
tests/terraform/go.mod
tests/terraform/go.sum
tests/terraform/module_test.go
[eclint/lint]: Project PASSED eclint test!
```

after:

```
[eclint/lint]: Running eclint...
cd /ci-harness/utils && \
[ -z "" ] || (echo "untracked changes detected!" && exit 1)
cd /ci-harness/utils && git ls-files -z | grep -zv ".bats" | xargs -0 -I {} echo {}
.bumpversion.cfg
.dependabot/config.yml
.editorconfig
.gitignore
.mergify.yml
.travis.yml
CHANGELOG.md
Dockerfile
LICENSE
Makefile
README.md
psmodules/P3Utils/P3Utils.psd1
psmodules/P3Utils/P3Utils.psm1
scripts/logit.cmd
scripts/unzip-archive.ps1
[eclint/lint]: Project PASSED eclint test!
```