### PR TITLE
Add pylint to the Makefile's python/lint target's recipe

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,3 +34,6 @@ indent_size = 1
 
 [LICENSE]
 indent_size = none
+
+[.pylintrc]
+indent_size = none

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,588 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=88
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM golang:1.15.5-buster
-ENV PATH="/root/.local/bin:/root/bin:${PATH}"
+FROM golang:1.15.5-buster as golang
+FROM python:3.8.6-buster
+ENV PATH="/root/.local/bin:/root/bin:/go/bin:/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
 RUN apt-get update -y && apt-get install -y \
     xz-utils \
     curl \
     jq \
     unzip \
     make \
-    python3.8 \
-    python3-pip \
 && rm -rf /var/lib/apt/lists/*
+COPY --from=golang /go/ /go/
+COPY --from=golang /usr/local/go/ /usr/local/go/
 COPY . /ci-harness
 RUN cd /ci-harness && make install
 WORKDIR /ci-harness

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -y && apt-get install -y \
     jq \
     unzip \
     make \
-    python3.7 \
+    python3.8 \
     python3-pip \
 && rm -rf /var/lib/apt/lists/*
 COPY . /ci-harness

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ python/%: PYTHON_FILES ?= git ls-files --cached --others --exclude-standard '*.p
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	$(PYTHON_FILES) | xargs black --check 
+	$(PYTHON_FILES) | xargs black --check
 	$(PYTHON_FILES) | $(XARGS) -n1 pylint -rn -sn \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
@@ -202,7 +202,7 @@ python/lint:
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."
-	$(PYTHON_FILES) | xargs black 
+	$(PYTHON_FILES) | xargs black
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files

--- a/Makefile
+++ b/Makefile
@@ -187,14 +187,14 @@ eclint/lint:
 	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES := git ls-files '*.py'
+python/%: PYTHON_FILES ?= git ls-files '*.py'
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
 	$(PYTHON_FILES) | xargs black --check
-	$(PYTHON_FILES) | ${XARGS} -n1 pylint -rn -sn \
+	$(PYTHON_FILES) | $(XARGS) -n1 pylint -rn -sn \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
 

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ eclint/lint:
 	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= git ls-files '*.py'
+python/%: PYTHON_FILES ?= git ls-files --others --exclude-standard '*.py'
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,8 @@ eclint/lint:
 	@ echo "[$@]: Project PASSED eclint test!"
 
 python/%: PYTHON_FILES := git ls-files '*.py'
-## Checks format and lints Python files.  Runs pylint on each individual 
-## file and uses a custom format for the lint messages.  
+## Checks format and lints Python files.  Runs pylint on each individual
+## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
@@ -200,7 +200,7 @@ python/lint:
 
 ## Formats Python files.
 python/format: | guard/program/black guard/program/git
-python/format: 
+python/format:
 	@ echo "[$@]: Formatting Python files..."
 	black $(PROJECT_ROOT)
 	@ echo "[$@]: Successfully formatted Python files!"

--- a/Makefile
+++ b/Makefile
@@ -188,22 +188,13 @@ eclint/lint:
 	@ echo "[$@]: Project PASSED eclint test!"
 
 python/%: PYTHON_FILES ?= git ls-files --cached --others --exclude-standard '*.py'
-# Black's exclude pattern matches against files and path names. 
-# Pylint's exclude pattern matches against the base name, not the path.
-# Black requires a value with it's exclude option, pylint does not.
-python/%: PYTHON_BLACK_EXCLUDES ?= 
-python/%: PYTHON_PYLINT_EXCLUDES ?= 
-python/%: BLACK_EXCLUDES_OPTION := $(shell [ ! -z "$(PYTHON_BLACK_EXCLUDES)" ] && echo "--force-exclude $(PYTHON_BLACK_EXCLUDES)" || echo "";)
-python/%: HAS_BLACK_EXCLUDE_OPTION := $(shell black --force-exclude xxx yyy 2>&1 | grep -q "no such option" || echo $$?;)
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	@ [ -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
-	$(PYTHON_FILES) | xargs black --check $(BLACK_EXCLUDES_OPTION)
+	$(PYTHON_FILES) | xargs black --check 
 	$(PYTHON_FILES) | $(XARGS) -n1 pylint -rn -sn \
-		--ignore-patterns=$(PYTHON_PYLINT_EXCLUDES) \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
 
@@ -211,8 +202,7 @@ python/lint:
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."
-	@ [ -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
-	$(PYTHON_FILES) | xargs black $(BLACK_EXCLUDES_OPTION)
+	$(PYTHON_FILES) | xargs black 
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ python/%: PYTHON_FILES := git ls-files '*.py'
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	$(PYTHON_FILES) | black --check $$(dirname {})
+	black --check $(PROJECT_ROOT)
 	$(PYTHON_FILES) | ${XARGS} -n1 pylint -rn -sn \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
@@ -202,7 +202,7 @@ python/lint:
 python/format: | guard/program/black guard/program/git
 python/format: 
 	@ echo "[$@]: Formatting Python files..."
-	$(PYTHON_FILES) | black $$(dirname {})
+	black $(PROJECT_ROOT)
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ python/%: HAS_BLACK_EXCLUDE_OPTION := $(shell black --force-exclude xxx yyy 2>&1
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	@ [ ! -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
+	@ [ -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
 	$(PYTHON_FILES) | xargs black --check $(BLACK_EXCLUDES_OPTION)
 	$(PYTHON_FILES) | $(XARGS) -n1 pylint -rn -sn \
 		--ignore-patterns=$(PYTHON_PYLINT_EXCLUDES) \
@@ -211,7 +211,7 @@ python/lint:
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."
-	@ [ ! -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
+	@ [ -z "$(PYTHON_BLACK_EXCLUDES)" -o $(HAS_BLACK_EXCLUDE_OPTION) -eq 1 ] || (echo "black v20.8b0 or higher is required if excluding files." && exit 1)
 	$(PYTHON_FILES) | xargs black $(BLACK_EXCLUDES_OPTION)
 	@ echo "[$@]: Successfully formatted Python files!"
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ python/%: PYTHON_FILES := git ls-files '*.py'
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	$(PYTHON_FILES) | xargs black --check 
+	$(PYTHON_FILES) | xargs black --check
 	$(PYTHON_FILES) | ${XARGS} -n1 pylint -rn -sn \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ eclint/lint:
 	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= git ls-files --others --exclude-standard '*.py'
+python/%: PYTHON_FILES ?= git ls-files --cached --others --exclude-standard '*.py'
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ install/pip/%: | guard/env/PYPI_PKG_NAME
 black/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
 
+pylint/install:
+	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
+
 yamllint/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
 
@@ -184,17 +187,22 @@ eclint/lint:
 	$(ECLINT_FILES) | grep -zv ".bats" | xargs -0 -I {} eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: FIND_PYTHON := find . $(FIND_EXCLUDES) -name '*.py' -type f
-## Lints Python files
-python/lint: | guard/program/black
+python/%: PYTHON_FILES := git ls-files '*.py'
+## Checks format and lints Python files.  Runs pylint on each individual 
+## file and uses a custom format for the lint messages.  
+python/lint: | guard/program/pylint guard/program/black guard/program/git
+python/lint:
 	@ echo "[$@]: Linting Python files..."
-	$(FIND_PYTHON) | $(XARGS) black --check $$(dirname {})
+	$(PYTHON_FILES) | black --check $$(dirname {})
+	$(PYTHON_FILES) | ${XARGS} -n1 pylint -rn -sn \
+		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
 
-## Formats Python files
-python/format: | guard/program/black
+## Formats Python files.
+python/format: | guard/program/black guard/program/git
+python/format: 
 	@ echo "[$@]: Formatting Python files..."
-	$(FIND_PYTHON) | $(XARGS) black $$(dirname {})
+	$(PYTHON_FILES) | black $$(dirname {})
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files
@@ -362,6 +370,6 @@ project/validate:
 	[ "$$(ls -A $(PROJECT_ROOT))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
-install: terraform/install shellcheck/install terraform-docs/install bats/install black/install eclint/install yamllint/install cfn-lint/install yq/install
+install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install eclint/install yamllint/install cfn-lint/install yq/install
 
 lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint eclint/lint cfn/lint hcl/lint

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ python/%: PYTHON_FILES := git ls-files '*.py'
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	black --check $(PROJECT_ROOT)
+	$(PYTHON_FILES) | xargs black --check 
 	$(PYTHON_FILES) | ${XARGS} -n1 pylint -rn -sn \
 		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
@@ -202,7 +202,7 @@ python/lint:
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."
-	black $(PROJECT_ROOT)
+	$(PYTHON_FILES) | xargs black
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
+test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9,
 EOF
 done
 

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -17,6 +17,8 @@ y8: 8, key9: 9, }
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'black format failure testing'
 }
 
 @test "python/format: failure" {
@@ -25,5 +27,6 @@ done
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -12,7 +12,8 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-print("foo"
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, ke
+y8: 8, key9: 9, }
 EOF
 done
 
@@ -20,7 +21,7 @@ done
 
 @test "python/format: failure" {
   run make python/format
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 1 ]
 }
 
 function teardown() {

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -22,7 +22,8 @@ git commit -m 'black format failure testing'
 
 @test "python/format: failure" {
   run make python/format
-  [ "$status" -eq 1 ]
+  # xargs returns 123 instead of the non-zero exit code from black.
+  [ "$status" -eq 123 ]
 }
 
 function teardown() {

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
+test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
 EOF
 done
 

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -15,9 +15,6 @@ do
 test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9,
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'black format failure testing'
 }
 
 @test "python/format: failure" {
@@ -26,6 +23,5 @@ git commit -m 'black format failure testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -12,8 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, ke
-y8: 8, key9: 9, }
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
 EOF
 done
 

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -22,8 +22,7 @@ git commit -m 'black format failure testing'
 
 @test "python/format: failure" {
   run make python/format
-  # xargs returns 123 instead of the non-zero exit code from black.
-  [ "$status" -eq 123 ]
+  [ "$status" -eq 2 ]
 }
 
 function teardown() {

--- a/tests/make/python_format_failure.bats
+++ b/tests/make/python_format_failure.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-TEST_DIR="$(pwd)/python_format_success"
+TEST_DIR="$(pwd)/python_format_failure"
 
 # generate a test terraform project with a nested project
 function setup() {
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
 EOF
 done
 

--- a/tests/make/python_format_success.bats
+++ b/tests/make/python_format_success.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-print("foo")
+test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
 EOF
 done
 

--- a/tests/make/python_format_success.bats
+++ b/tests/make/python_format_success.bats
@@ -16,6 +16,8 @@ print("foo")
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'black format success testing'
 }
 
 @test "python/format: success" {
@@ -25,5 +27,6 @@ done
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_format_success.bats
+++ b/tests/make/python_format_success.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
+test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9, }
 EOF
 done
 

--- a/tests/make/python_format_success.bats
+++ b/tests/make/python_format_success.bats
@@ -15,9 +15,6 @@ do
 test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9, }
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'black format success testing'
 }
 
 @test "python/format: success" {
@@ -27,6 +24,5 @@ git commit -m 'black format success testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -15,9 +15,6 @@ do
 test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9,
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'black lint failure testing'
 }
 
 @test "python/lint black: failure" {
@@ -26,6 +23,5 @@ git commit -m 'black lint failure testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/python_lint_black_failure"
+
+# generate a test terraform project with a nested project
+function setup() {
+rm -rf "$TEST_DIR"
+working_dirs=("$TEST_DIR" "$TEST_DIR/nested")
+for working_dir in "${working_dirs[@]}"
+do
+
+  mkdir -p "$working_dir"
+  cat > "$working_dir/test.py" <<"EOF"
+
+print("foo")
+EOF
+done
+
+}
+
+@test "python/lint black: failure" {
+  run make python/lint
+  [ "$status" -eq 2 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
+test_dict = { "key1": 1, "key2": 2, "key3": 3, "key4": 4, "key5": 5, "key6": 6, "key7": 7, "key8": 8, "key9": 9,
 EOF
 done
 

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -17,6 +17,9 @@ y8: 8, key9: 9, }
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'black lint failure testing'
+
 }
 
 @test "python/lint black: failure" {
@@ -25,5 +28,6 @@ done
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -12,7 +12,8 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-print("foo")
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, ke
+y8: 8, key9: 9, }
 EOF
 done
 
@@ -20,7 +21,7 @@ done
 
 @test "python/lint black: failure" {
   run make python/lint
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 1 ]
 }
 
 function teardown() {

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
 EOF
 done
 

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -22,7 +22,8 @@ git commit -m 'black lint failure testing'
 
 @test "python/lint black: failure" {
   run make python/lint
-  [ "$status" -eq 1 ]
+  # xargs returns 123 instead of the non-zero exit code from black.
+  [ "$status" -eq 123 ]
 }
 
 function teardown() {

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -12,7 +12,7 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
+test_dict = { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9,
 EOF
 done
 

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -12,14 +12,12 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, ke
-y8: 8, key9: 9, }
+test_dict == { key1: 1, key2: 2, key3: 3, key4: 4, key5: 5, key6: 6, key7: 7, key8: 8, key9: 9, }
 EOF
 done
 
 git add "$TEST_DIR/."
 git commit -m 'black lint failure testing'
-
 }
 
 @test "python/lint black: failure" {

--- a/tests/make/python_lint_black_failure.bats
+++ b/tests/make/python_lint_black_failure.bats
@@ -22,8 +22,7 @@ git commit -m 'black lint failure testing'
 
 @test "python/lint black: failure" {
   run make python/lint
-  # xargs returns 123 instead of the non-zero exit code from black.
-  [ "$status" -eq 123 ]
+  [ "$status" -eq 2 ]
 }
 
 function teardown() {

--- a/tests/make/python_lint_black_success.bats
+++ b/tests/make/python_lint_black_success.bats
@@ -11,6 +11,7 @@ do
 
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
+"""Simple print test"""
 print("foo")
 EOF
 done

--- a/tests/make/python_lint_black_success.bats
+++ b/tests/make/python_lint_black_success.bats
@@ -15,9 +15,6 @@ do
 print("foo")
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'black lint success testing'
 }
 
 @test "python/lint black: success" {
@@ -26,6 +23,5 @@ git commit -m 'black lint success testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_lint_black_success.bats
+++ b/tests/make/python_lint_black_success.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-TEST_DIR="$(pwd)/python_lint_success"
+TEST_DIR="$(pwd)/python_lint_black_success"
 
 # generate a test terraform project with a nested project
 function setup() {
@@ -17,7 +17,7 @@ done
 
 }
 
-@test "python/lint: success" {
+@test "python/lint black: success" {
   run make python/lint
   [ "$status" -eq 0 ]
 }

--- a/tests/make/python_lint_black_success.bats
+++ b/tests/make/python_lint_black_success.bats
@@ -15,6 +15,8 @@ print("foo")
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'black lint success testing'
 }
 
 @test "python/lint black: success" {
@@ -23,5 +25,6 @@ done
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_lint_black_success.bats
+++ b/tests/make/python_lint_black_success.bats
@@ -20,6 +20,7 @@ done
 @test "python/lint black: success" {
   run make python/lint
   [ "$status" -eq 0 ]
+  [[ "$output" == *"2 files would be left unchanged"* ]]
 }
 
 function teardown() {

--- a/tests/make/python_lint_pylint_failure.bats
+++ b/tests/make/python_lint_pylint_failure.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-TEST_DIR="$(pwd)/python_lint_failure"
+TEST_DIR="$(pwd)/python_lint_pylint_failure"
 
 # generate a test terraform project with a nested project
 function setup() {
@@ -12,13 +12,14 @@ do
   mkdir -p "$working_dir"
   cat > "$working_dir/test.py" <<"EOF"
 
-print("foo")
+import json
+import os
 EOF
 done
 
 }
 
-@test "python/lint: failure" {
+@test "python/lint pylint: failure" {
   run make python/lint
   [ "$status" -eq 2 ]
 }

--- a/tests/make/python_lint_pylint_failure.bats
+++ b/tests/make/python_lint_pylint_failure.bats
@@ -17,13 +17,17 @@ import os
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'pylint lint failure testing'
 }
 
 @test "python/lint pylint: failure" {
   run make python/lint
-  [ "$status" -eq 2 ]
+  # xargs returns 123 instead of the non-zero exit code from pylint.
+  [ "$status" -eq 123 ]
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_lint_pylint_failure.bats
+++ b/tests/make/python_lint_pylint_failure.bats
@@ -23,8 +23,7 @@ git commit -m 'pylint lint failure testing'
 
 @test "python/lint pylint: failure" {
   run make python/lint
-  # xargs returns 123 instead of the non-zero exit code from pylint.
-  [ "$status" -eq 123 ]
+  [ "$status" -eq 2 ]
 }
 
 function teardown() {

--- a/tests/make/python_lint_pylint_failure.bats
+++ b/tests/make/python_lint_pylint_failure.bats
@@ -16,9 +16,6 @@ import json
 import os
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'pylint lint failure testing'
 }
 
 @test "python/lint pylint: failure" {
@@ -27,6 +24,5 @@ git commit -m 'pylint lint failure testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -17,9 +17,6 @@ import os
 print(os.name)
 EOF
 done
-
-git add "$TEST_DIR/."
-git commit -m 'pylint lint success testing'
 }
 
 @test "python/lint pylint: success" {
@@ -28,6 +25,5 @@ git commit -m 'pylint lint success testing'
 }
 
 function teardown() {
-  git rm -r -f "$TEST_DIR"
-  git reset --hard HEAD^
+  rm -rf "$TEST_DIR"
 }

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -21,6 +21,7 @@ done
 
 @test "python/lint pylint: success" {
   run make python/lint
+  # If there are no pylint issues, there will be no pylint output.
   [ "$status" -eq 0 ]
 }
 

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -25,7 +25,6 @@ git commit -m 'pylint lint success testing'
 @test "python/lint pylint: success" {
   run make python/lint
   [ "$status" -eq 0 ]
-  [[ "$output" != *"**********"* ]]
 }
 
 function teardown() {

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -18,13 +18,17 @@ print("os.name")
 EOF
 done
 
+git add "$TEST_DIR/."
+git commit -m 'pylint lint success testing'
 }
 
 @test "python/lint pylint: success" {
   run make python/lint
   [ "$status" -eq 0 ]
+  [[ "$output" != *"**********"* ]]
 }
 
 function teardown() {
-  rm -rf "$TEST_DIR"
+  git rm -r -f "$TEST_DIR"
+  git reset --hard HEAD^
 }

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -14,7 +14,7 @@ do
 """Simple test of pylint"""
 import os
 
-print("os.name")
+print(os.name)
 EOF
 done
 

--- a/tests/make/python_lint_pylint_success.bats
+++ b/tests/make/python_lint_pylint_success.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/python_lint_pylint_success"
+
+# generate a test terraform project with a nested project
+function setup() {
+rm -rf "$TEST_DIR"
+working_dirs=("$TEST_DIR" "$TEST_DIR/nested")
+for working_dir in "${working_dirs[@]}"
+do
+
+  mkdir -p "$working_dir"
+  cat > "$working_dir/test.py" <<"EOF"
+"""Simple test of pylint"""
+import os
+
+print("os.name")
+EOF
+done
+
+}
+
+@test "python/lint pylint: success" {
+  run make python/lint
+  [ "$status" -eq 0 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}


### PR DESCRIPTION
When the 'python/lint' target is executed, both black and pylint will now be executed against python files within the repo.  The changes include:

* Updating Dockerfile to change python3.7 to python3.8.
* Modifying the Makefile to add a target pylint/install and to add pylint/install to the install target.
* Modifying the Makefile's python/lint target to add a pylint command.
* Adding a .pylintrc file with max-line-length set to 88.
