### PR TITLE
pylint and black find no python files outside of tardigrade-ci

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --oth
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	black --check $(PYTHON_FILES) 
+	black --check $(PYTHON_FILES)
 	for python_file in $(PYTHON_FILES); do \
 		if [[ $$python_file = *.py ]]; then \
 			pylint --msg-template="{path}:{line} [{symbol}] {msg}" \

--- a/Makefile
+++ b/Makefile
@@ -188,23 +188,22 @@ eclint/lint:
 		$(XARGS) -0 eclint check $(PROJECT_ROOT)/{}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py'
+python/%: PYTHON_FILES ?= git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)/%s\n"
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	$(PYTHON_FILES) | xargs printf "$(PROJECT_ROOT)/%s " | xargs black --check
+	$(PYTHON_FILES) | xargs black --check
 	$(PYTHON_FILES) | $(XARGS) -n1 pylint -rn -sn \
-		--msg-template="{path}:{line} [{symbol}] {msg}" \
-		$(PROJECT_ROOT)/{}
+		--msg-template="{path}:{line} [{symbol}] {msg}" {}
 	@ echo "[$@]: Python files PASSED lint test!"
 
 ## Formats Python files.
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."
-	$(PYTHON_FILES) | xargs printf "$(PROJECT_ROOT)/%s " | xargs black
+	$(PYTHON_FILES) | xargs black
 	@ echo "[$@]: Successfully formatted Python files!"
 
 ## Lints terraform files

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ eclint/lint:
 	eclint check $(ECLINT_FILES)
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)/%s ")
+python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs --no-run-if-empty printf "$(PROJECT_ROOT)/%s ")
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
@@ -194,10 +194,8 @@ python/lint:
 	@ echo "[$@]: Linting Python files..."
 	black --check $(PYTHON_FILES)
 	for python_file in $(PYTHON_FILES); do \
-		if [[ $$python_file = *.py ]]; then \
-			pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
-				-rn -sn $$python_file; \
-		fi \
+		pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
+			-rn -sn $$python_file; \
 	done
 	echo "[$@]: Python files PASSED lint test!"
 

--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,10 @@ eclint/lint:
 	[ -z "$(HAS_UNTRACKED_CHANGES)" ] || (echo "untracked changes detected!" && exit 1)
 	cd $(PROJECT_ROOT) && \
 	$(ECLINT_FILES) | grep -zv ".bats" | \
-		$(XARGS) -0 eclint check $(PROJECT_ROOT)/{}
+		$(XARGS) -0 eclint check $(PROJECT_ROOT){}
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)/%s\n"
+python/%: PYTHON_FILES ?= git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)%s\n"
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git

--- a/Makefile
+++ b/Makefile
@@ -178,14 +178,12 @@ cfn/lint: | guard/program/cfn-lint
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell cd $(PROJECT_ROOT) && git status -s)
-eclint/lint: ECLINT_FILES ?= git -C $(PROJECT_ROOT) ls-files -z
+eclint/lint: ECLINT_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files -z | grep -zv ".bats" | xargs -0)
 eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \
 	[ -z "$(HAS_UNTRACKED_CHANGES)" ] || (echo "untracked changes detected!" && exit 1)
-	cd $(PROJECT_ROOT) && \
-	$(ECLINT_FILES) | grep -zv ".bats" | \
-		$(XARGS) -0 eclint check $(PROJECT_ROOT){}
+	ls $(ECLINT_FILES) | $(XARGS) eclint check {}
 	@ echo "[$@]: Project PASSED eclint test!"
 
 python/%: PYTHON_FILES ?= git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)%s\n"

--- a/Makefile
+++ b/Makefile
@@ -192,11 +192,13 @@ python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --oth
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	black --check $(PYTHON_FILES)
-	for python_file in $(PYTHON_FILES); do \
-		pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
-			-rn -sn $$python_file; \
-	done
+	@ [[ ! -z "$(findstring .py, $(PYTHON_FILES))" ]] && \
+		black --check $(PYTHON_FILES) && \
+		for python_file in $(PYTHON_FILES); do \
+			pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
+				-rn -sn $$python_file; \
+	done || \
+		(echo "No python files to lint."; exit 0)
 	@ echo "[$@]: Python files PASSED lint test!"
 
 ## Formats Python files.

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ eclint/lint:
 	eclint check $(ECLINT_FILES)
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)%s ")
+python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs printf "$(PROJECT_ROOT)/%s ")
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git

--- a/Makefile
+++ b/Makefile
@@ -192,14 +192,14 @@ python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --oth
 python/lint: | guard/program/pylint guard/program/black guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
-	@ [[ ! -z "$(findstring .py, $(PYTHON_FILES))" ]] && \
-		black --check $(PYTHON_FILES) && \
-		for python_file in $(PYTHON_FILES); do \
+	black --check $(PYTHON_FILES) 
+	for python_file in $(PYTHON_FILES); do \
+		if [[ $$python_file = *.py ]]; then \
 			pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
 				-rn -sn $$python_file; \
-	done || \
-		(echo "No python files to lint."; exit 0)
-	@ echo "[$@]: Python files PASSED lint test!"
+		fi \
+	done
+	echo "[$@]: Python files PASSED lint test!"
 
 ## Formats Python files.
 python/format: | guard/program/black guard/program/git

--- a/tests/make/eclint_lint_success.bats
+++ b/tests/make/eclint_lint_success.bats
@@ -18,11 +18,11 @@ done
 
 git add "$TEST_DIR/."
 git commit -m 'eclint success testing'
-
 }
 
 @test "eclint/lint: success" {
-  run make eclint/lint
+  ECLINT_FILES=$(find "${TEST_DIR}" -type f | xargs echo)
+  run make eclint/lint ECLINT_FILES="${ECLINT_FILES}"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/make/python_format_success.bats
+++ b/tests/make/python_format_success.bats
@@ -21,6 +21,10 @@ done
   run make python/format
   [ "$status" -eq 0 ]
   [[ "$output" == *"[python/format]: Successfully formatted Python files!"* ]]
+
+  run make python/format PYTHON_FILES="$TEST_DIR/nested/*.py"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 file left unchanged"* ]]
 }
 
 function teardown() {


### PR DESCRIPTION
The Makefile is searching git for python files for input to pylint and black, but finds none outside of tardigrade-ci itself.  This problem exists for eclint as well.  All three Makefile targets have been fixed with this pull request.

Loren determined that the problem is caused by the logic that uses 'git ls-files' to find python files in the repo.  The dockerfile created to run tardigrade-ci's Makefile pulls in the tardigrade-ci files, then creates a subdirectory (ci-harness) for the repo 'under test'.  The 'git ls-files --cached --others --exclude-standard' will find git files in tardigrade-ci, but not in the git repo in the subdirectory (ci-harness).

To work around this problem, the tardigrade-ci Makefile needed to ignore tardigrade-ci's git files and focus on the git repo in the subdirectory (ci-harness).  The Makefile refers to this repo location as $(PROJECT_ROOT).  

The 'git ls-files ...' command has been changed to 'git -C $(PROJECT_ROOT) ls-files ...' and the eclint, pylint and black commands refer to files off of $PROJECT_ROOT.

The Makefile variables ECLINT_FILES and PYTHON_FILES were also 'cleaned up' so the user can provide a list of files to the Makefile eclint/lint, python/format or python/lint targets.  Unit tests have been added to test setting those variables.

There is an issue with eclint tests that necessitates specifying ECLINT_FILES in order for the tests to run successfully.  Since eclint will be replaced through work on a different task, setting ECLINT_FILES was used as a workaround.

There is also an issue with the docker targets in the Makefile.  PROJECT_ROOT should end with a trailing slash, but the docker arguments omit the slash for this variable.  I tried fixing the problem, but there appears to be a circular dependency between PROJECT_ROOT and PROJECT_NAME in .tardigrade-ci.  This is also a different task for someone to fix.  For now, the lint logic assumes there will be no trailing slash.