### PR TITLE
Fix git path for eclint files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.3.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ cfn/lint: | guard/program/cfn-lint
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell cd $(PROJECT_ROOT) && git status -s)
-eclint/lint: ECLINT_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files -z | grep -zv ".bats" | xargs -0 --no-run-if-empty printf "$(PROJECT_ROOT)/%s ")
+eclint/lint: ECLINT_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files -z | grep -zv ".bats" | xargs -0 --no-run-if-empty printf "$(PROJECT_ROOT)%s ")
 eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \
@@ -186,7 +186,7 @@ eclint/lint:
 	eclint check $(ECLINT_FILES)
 	@ echo "[$@]: Project PASSED eclint test!"
 
-python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs --no-run-if-empty printf "$(PROJECT_ROOT)/%s ")
+python/%: PYTHON_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files --cached --others --exclude-standard '*.py' | xargs --no-run-if-empty printf "$(PROJECT_ROOT)%s ")
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/git
@@ -320,7 +320,7 @@ docker/run: docker/build
 	-e AWS_PROFILE=$(AWS_PROFILE) \
 	-e AWS_SHARED_CREDENTIALS_FILE=/.aws/credentials \
 	-e INCLUDE=/ci-harness/$(PROJECT_NAME)/Makefile \
-	-e PROJECT_ROOT=/ci-harness/$(PROJECT_NAME) \
+	-e PROJECT_ROOT=/ci-harness/$(PROJECT_NAME)/ \
 	$(IMAGE_NAME) $(target)
 
 ## Cleans local docker environment

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ cfn/lint: | guard/program/cfn-lint
 ## Runs eclint against the project
 eclint/lint: | guard/program/eclint guard/program/git
 eclint/lint: HAS_UNTRACKED_CHANGES ?= $(shell cd $(PROJECT_ROOT) && git status -s)
-eclint/lint: ECLINT_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files -z | grep -zv ".bats" | xargs -0)
+eclint/lint: ECLINT_FILES ?= $(shell git -C $(PROJECT_ROOT) ls-files -z | grep -zv ".bats" | xargs -0 --no-run-if-empty printf "$(PROJECT_ROOT)/%s ")
 eclint/lint:
 	@ echo "[$@]: Running eclint..."
 	cd $(PROJECT_ROOT) && \

--- a/tests/make/eclint_lint_success.bats
+++ b/tests/make/eclint_lint_success.bats
@@ -21,6 +21,9 @@ git commit -m 'eclint success testing'
 }
 
 @test "eclint/lint: success" {
+  run make eclint/lint 
+  [ "$status" -eq 0 ]
+
   ECLINT_FILES=$(find "${TEST_DIR}" -type f | xargs echo)
   run make eclint/lint ECLINT_FILES="${ECLINT_FILES}"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The prior fix to add pylint and black to the Makefile did not have all the necessary corrections for eclint.  For this fix, I tested the following scenarios and they all passed (results will be added in another comment):

- tardigrade-ci:  make bats/test
- tardigrade-modules:  make eclint/lint
- tardigrade-modules:  create the docker image and run make eclint/lint

This test scenario will now fail due to the value of PROJECT_ROOT, but that problem will be handled by another task:

- tardigrade-ci:  make eclint/lint