### PR TITLE
Mounts current working directory to docker WORKDIR

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.6.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.dummy_include
+++ b/.dummy_include
@@ -1,1 +1,0 @@
-# intentionally left blank

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ SHELL := bash
 DEFAULT_HELP_TARGET ?= help
 HELP_FILTER ?= .*
 
-green = $(shell echo -e '\x1b[32;01m$1\x1b[0m')
-yellow = $(shell echo -e '\x1b[33;01m$1\x1b[0m')
-red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
-
 export SELF ?= $(MAKE)
 
 default:: $(DEFAULT_HELP_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ cfn/%: FIND_CFN ?= find . $(FIND_EXCLUDES) -name '*.template.cfn.*' -type f
 cfn/lint: | guard/program/cfn-lint
 	$(FIND_CFN) | $(XARGS) cfn-lint -t {}
 
-## Runs editorconfig-checker, aka 'ec',  against the project
+## Runs editorconfig-checker, aka 'ec', against the project
 ec/lint: | guard/program/ec guard/program/git
 ec/lint: ECLINT_FILES ?= $(shell git ls-files | grep -v ".bats")
 ec/lint:
@@ -186,8 +186,7 @@ ec/lint:
 	@ echo "[$@]: Project PASSED ec lint test!"
 
 python/%: PYTHON_FILES ?= $(shell git ls-files --cached --others --exclude-standard '*.py')
-## Checks format and lints Python files.  Runs pylint on each individual
-## file and uses a custom format for the lint messages.
+## Checks format and lints Python files
 python/lint: | guard/program/pylint guard/program/black guard/program/pydocstyle guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
@@ -199,7 +198,7 @@ python/lint:
 	pydocstyle $(PYTHON_FILES)
 	echo "[$@]: Python files PASSED lint test!"
 
-## Formats Python files.
+## Formats Python files
 python/format: | guard/program/black guard/program/git
 python/format:
 	@ echo "[$@]: Formatting Python files..."

--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,13 @@ cfn/lint: | guard/program/cfn-lint
 
 ## Runs editorconfig-checker, aka 'ec',  against the project
 ec/lint: | guard/program/ec guard/program/git
-ec/lint: ECLINT_FILES ?= $(shell git ls-files -z | grep -zv ".bats" | xargs -0 --no-run-if-empty printf "%s ")
+ec/lint: ECLINT_FILES ?= $(shell git ls-files | grep -v ".bats")
 ec/lint:
 	@ echo "[$@]: Running ec..."
 	ec $(ECLINT_FILES)
 	@ echo "[$@]: Project PASSED ec lint test!"
 
-python/%: PYTHON_FILES ?= $(shell git ls-files --cached --others --exclude-standard '*.py' | xargs --no-run-if-empty printf "%s ")
+python/%: PYTHON_FILES ?= $(shell git ls-files --cached --others --exclude-standard '*.py')
 ## Checks format and lints Python files.  Runs pylint on each individual
 ## file and uses a custom format for the lint messages.
 python/lint: | guard/program/pylint guard/program/black guard/program/pydocstyle guard/program/git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available targets:
   docker/run                          Runs the tardigrade-ci docker image
   docs/generate                       Generates Terraform documentation
   docs/lint                           Lints Terraform documentation
-  ec/lint                             Runs editorconfig-checker, aka 'ec',  against the project
+  ec/lint                             Runs editorconfig-checker, aka 'ec', against the project
   hcl/format                          Formats hcl files
   hcl/lint                            Lints hcl files
   hcl/validate                        Validates hcl files
@@ -27,8 +27,8 @@ Available targets:
   init                                Init build-harness
   json/format                         Formats json files
   json/lint                           Lints json files
-  python/format                       Formats Python files.
-  python/lint                         file and uses a custom format for the lint messages.
+  python/format                       Formats Python files
+  python/lint                         Checks format and lints Python files
   sh/lint                             Lints bash script files
   terraform/format                    Formats terraform files
   terraform/lint                      Lints terraform files

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ with the following content.
   tardigrade-ci/
   ```
 
-4. Run `make` once to initialize the project and then `make docker/run target=<TARGET>`
+4. Run `make init` once to initialize the project and then `make docker/run target=<TARGET>`.
 
 5. Additionally, you can use the tardigrade-ci/Makefile vars and targets
 directly in your own Makefile. For example, there is a target for installing

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This project can be utilized one of two ways, via docker or via a Makefile inclu
   ```bash
   IMAGE="plus3it/tardigrade-ci:latest"
   docker pull "$IMAGE"
-  docker run --rm -ti -v "my-project-dir/:/ci-harness/" "$IMAGE" helps
+  docker run --rm -ti -v "my-project-dir/:/ci-harness/" "$IMAGE" help
   ```
 
 ### Makefile Include

--- a/README.md
+++ b/README.md
@@ -13,16 +13,22 @@ below:
 Available targets:
 
   cfn/lint                            Lints CloudFormation files
+  clean                               Clean build-harness
+  docker/build                        Builds the tardigrade-ci docker image
+  docker/clean                        Cleans local docker environment
+  docker/run                          Runs the tardigrade-ci docker image
   docs/generate                       Generates Terraform documentation
   docs/lint                           Lints Terraform documentation
-  eclint/lint                         Runs eclint against the project
+  ec/lint                             Runs editorconfig-checker, aka 'ec',  against the project
   hcl/format                          Formats hcl files
   hcl/lint                            Lints hcl files
+  hcl/validate                        Validates hcl files
   help                                This help screen
+  init                                Init build-harness
   json/format                         Formats json files
   json/lint                           Lints json files
-  python/format                       Formats Python files
-  python/lint                         Lints Python files
+  python/format                       Formats Python files.
+  python/lint                         file and uses a custom format for the lint messages.
   sh/lint                             Lints bash script files
   terraform/format                    Formats terraform files
   terraform/lint                      Lints terraform files

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 A docker based test framework
 
-This project packages the make targets that provide the tools and command shortcuts Plus3IT uses to develop and maintain our terraform modules.
+This project packages the make targets that provide the tools and command shortcuts
+Plus3IT uses to develop and maintain projects of all sorts.
 
-The makefile in this repository has been exposed as the entry point to the accompanying docker image. A list of the available make targets are provided below:
+The targets in this tardigrade-ci Makefile are included when using the accompanying
+docker image with your own project. A list of the available make targets are provided
+below:
 
 ```bash
 Available targets:
@@ -38,17 +41,19 @@ This project can be utilized one of two ways, via docker or via a Makefile inclu
   ```bash
   IMAGE="plus3it/tardigrade-ci:latest"
   docker pull "$IMAGE"
-  docker run --rm -ti -v "my-project-dir:/ci-harness/my-project" "$IMAGE" helps
+  docker run --rm -ti -v "my-project-dir/:/ci-harness/" "$IMAGE" helps
   ```
 
 ### Makefile Include
 
-1. Create a Dockerfile in the project in which you wish to utilize these ci tools with the following content.
+1. Create a Dockerfile in the project in which you wish to utilize these ci tools
+with the following content.
 
-  **NOTE:** This Dockerfile is intended to be used to enable version pinning of the underlying toolset.
+  **NOTE:** This Dockerfile is intended to be used to enable version pinning of
+  the underlying toolset.
 
   ```bash
-  FROM plus3it/tardigrade-ci:0.0.2
+  FROM plus3it/tardigrade-ci:0.6.0
 
   WORKDIR /ci-harness
   ENTRYPOINT ["make"]
@@ -68,9 +73,6 @@ This project can be utilized one of two ways, via docker or via a Makefile inclu
   # tardigrade-ci
   .tardigrade-ci
   tardigrade-ci/
-
-  # eclint
-  .git/
   ```
 
 4. Run `make` once to initialize the project and then `make docker/run target=<TARGET>`

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -4,10 +4,6 @@ export TARDIGRADE_CI_PROJECT ?= tardigrade-ci
 export TARDIGRADE_CI_BRANCH ?= master
 export TARDIGRADE_CI_PATH ?= $(shell until [ -d "$(TARDIGRADE_CI_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(TARDIGRADE_CI_PROJECT)
 
-export MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-export PROJECT_ROOT ?= $(dir $(MAKEFILE_PATH))
-export PROJECT_NAME := $(notdir $(patsubst %/,%,$(PROJECT_ROOT)))
-
 -include $(TARDIGRADE_CI_PATH)/Makefile
 
 .PHONY : init

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -12,7 +12,7 @@ init::
 	@curl --retry 5 --fail --silent --retry-delay 1 https://raw.githubusercontent.com/$(TARDIGRADE_CI_ORG)/$(TARDIGRADE_CI_PROJECT)/$(TARDIGRADE_CI_BRANCH)/bootstrap/bin/install.sh | \
 		bash -s "$(TARDIGRADE_CI_ORG)" "$(TARDIGRADE_CI_PROJECT)" "$(TARDIGRADE_CI_BRANCH)"
 
-.PHONY : cleans
+.PHONY : clean
 ## Clean build-harness
 clean::
 	@[ "$(TARDIGRADE_CI_PATH)" == '/' ] || \

--- a/tests/make/Makefile
+++ b/tests/make/Makefile
@@ -1,4 +1,3 @@
 export YAMLLINT_CONFIG := ../../.yamllint.yml
-export PROJECT_ROOT := ../../
 
 -include ../../Makefile

--- a/tests/make/project_validate_failure.bats
+++ b/tests/make/project_validate_failure.bats
@@ -9,8 +9,8 @@ mkdir "$TEST_DIR"
 
 }
 
-@test "project/validate: success" {
-  run make project/validate PROJECT_ROOT="$TEST_DIR"
+@test "project/validate: failure" {
+  run make project/validate PWD="$TEST_DIR"
   [ "$status" -eq 2 ]
 }
 


### PR DESCRIPTION
This eliminates the layer of indirection where the using project
is available in the container at /ci-harness/<project_name>.

With this change, running make targets in the container is the same as
running make targets outside the container.