### PR TITLE
Attempts to retrieve version from Dockerfile when bootstrapping tardigrade-ci

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -1,7 +1,7 @@
 export SHELL = /bin/bash
 export TARDIGRADE_CI_ORG ?= plus3it
 export TARDIGRADE_CI_PROJECT ?= tardigrade-ci
-export TARDIGRADE_CI_BRANCH ?= master
+export TARDIGRADE_CI_BRANCH ?= $(or $(shell grep 'FROM $(TARDIGRADE_CI_ORG)/$(TARDIGRADE_CI_PROJECT)' Dockerfile | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' 2> /dev/null),master)
 export TARDIGRADE_CI_PATH ?= $(shell until [ -d "$(TARDIGRADE_CI_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(TARDIGRADE_CI_PROJECT)
 
 -include $(TARDIGRADE_CI_PATH)/Makefile

--- a/bootstrap/bin/install.sh
+++ b/bootstrap/bin/install.sh
@@ -12,4 +12,4 @@ fi
 
 echo "Cloning ${GITHUB_REPO}#${TARDIGRADE_CI_BRANCH}..."
 
-git clone -b "$TARDIGRADE_CI_BRANCH" "$GITHUB_REPO"
+git clone -c advice.detachedHead=false --depth=1 -b "$TARDIGRADE_CI_BRANCH" "$GITHUB_REPO"


### PR DESCRIPTION
With the change to how the container is mounted in v0.6.0, projects would *always* retrieve the latest Makefile even when pinning an earlier version of the docker container. This could cause unexpected CI failures in work unrelated to an update of the container.

You can see an example of the failure in this PR:

* https://github.com/plus3it/terraform-aws-remote-access/pull/119

Even though the project pins tardigrade-ci 0.2.0 for the docker container, it is still receiving the latest Makefile on `make init`, which causes it to run the latest python/lint target instead of the version from 0.2.0.