### PR TITLE
Add bumpversion as an installable Makefile target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apt-get update -y && apt-get install -y \
 COPY --from=golang /go/ /go/
 COPY --from=golang /usr/local/go/ /usr/local/go/
 COPY . /ci-harness
-RUN cd /ci-harness && make install
+RUN make -C /ci-harness install
 WORKDIR /ci-harness
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,6 @@ cfn-lint/install:
 yq/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
 
-bumpversion/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
-
 node/install: NODE_VERSION ?= 10.x
 node/install: NODE_SOURCE ?= https://deb.nodesource.com/setup_$(NODE_VERSION)
 node/install:
@@ -364,6 +361,6 @@ project/validate:
 	[ "$$(ls -A $(PWD))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
-install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install bumpversion/install
+install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install
 
 lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint ec/lint cfn/lint hcl/lint

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,13 @@ ec/install:
 	$(@D) --version
 	@ echo "[$@]: Completed successfully!"
 
+install/pip: CUSTOM_VERSION_CMD ?= ''
 install/pip/%: PYTHON ?= python3
 install/pip/%: | guard/env/PYPI_PKG_NAME
 	@ echo "[$@]: Installing $*..."
 	$(PYTHON) -m pip install --user $(PYPI_PKG_NAME)
 	ln -sf ~/.local/bin/$* $(BIN_DIR)/$*
-	$* --version
+	$(if $(CUSTOM_VERSION_CMD),$(CUSTOM_VERSION_CMD),$* --version)
 	@ echo "[$@]: Completed successfully!"
 
 black/install:
@@ -145,6 +146,11 @@ cfn-lint/install:
 
 yq/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
+
+bump2version/install:
+	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D) CUSTOM_VERSION_CMD="bumpversion -h | grep 'bumpversion: v'"
+
+bumpversion/install: bump2version/install
 
 node/install: NODE_VERSION ?= 10.x
 node/install: NODE_SOURCE ?= https://deb.nodesource.com/setup_$(NODE_VERSION)
@@ -361,6 +367,6 @@ project/validate:
 	[ "$$(ls -A $(PWD))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
-install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install
+install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install bumpversion/install
 
 lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint ec/lint cfn/lint hcl/lint

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,9 @@ cfn-lint/install:
 yq/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
 
+bumpversion/install:
+	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
+
 node/install: NODE_VERSION ?= 10.x
 node/install: NODE_SOURCE ?= https://deb.nodesource.com/setup_$(NODE_VERSION)
 node/install:
@@ -361,6 +364,6 @@ project/validate:
 	[ "$$(ls -A $(PWD))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
-install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install
+install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install bumpversion/install
 
 lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint ec/lint cfn/lint hcl/lint


### PR DESCRIPTION
bumpversion is no longer a supported repo, but bump2version is a replacement and uses an executable of 'bumpversion'.  The new Makefile target of bumpversion internally invokes the installation of bump2version.