### PR TITLE
Mounts TARDIGRADE_CI_PATH to the docker container

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.6.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ docker/run: docker/build
 	@echo "[$@]: Running docker image"
 	docker run $(DOCKER_RUN_FLAGS) \
 	-v "$(PWD)/:/ci-harness/" \
-	-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/" \
+	$(if $(strip $(TARDIGRADE_CI_PATH)),-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/",) \
 	-v "$(HOME)/.aws/:/root/.aws/" \
 	-e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
 	-e AWS_PROFILE=$(AWS_PROFILE) \

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ docker/run: docker/build
 	@echo "[$@]: Running docker image"
 	docker run $(DOCKER_RUN_FLAGS) \
 	-v "$(PWD)/:/ci-harness/" \
-	$(if $(strip $(TARDIGRADE_CI_PATH)),-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/",) \
+	-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/" \
 	-v "$(HOME)/.aws/:/root/.aws/" \
 	-e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
 	-e AWS_PROFILE=$(AWS_PROFILE) \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ SHELL := bash
 DEFAULT_HELP_TARGET ?= help
 HELP_FILTER ?= .*
 
+TARDIGRADE_CI_PATH ?= $(PWD)
+TARDIGRADE_CI_PROJECT ?= tardigrade-ci
+
 export SELF ?= $(MAKE)
 
 default:: $(DEFAULT_HELP_TARGET)
@@ -308,6 +311,7 @@ docker/build:
 docker/run: DOCKER_RUN_FLAGS ?= --rm
 docker/run: AWS_DEFAULT_REGION ?= us-east-1
 docker/run: target ?= help
+docker/run: | guard/env/TARDIGRADE_CI_PATH guard/env/TARDIGRADE_CI_PROJECT
 docker/run: docker/build
 	@echo "[$@]: Running docker image"
 	docker run $(DOCKER_RUN_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,8 @@ docker/run: docker/build
 	@echo "[$@]: Running docker image"
 	docker run $(DOCKER_RUN_FLAGS) \
 	-v "$(PWD)/:/ci-harness/" \
-	-v "$(HOME)/.aws:/root/.aws" \
+	-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/" \
+	-v "$(HOME)/.aws/:/root/.aws/" \
 	-e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
 	-e AWS_PROFILE=$(AWS_PROFILE) \
 	$(IMAGE_NAME) $(target)


### PR DESCRIPTION
TARDIGRADE_CI_PATH has logic that will resolve to a TARDIGRADE_CI_PROJECT
directory that is one of:

* A subdirectory of the current project. This is what `make init` sets up,
when it clones the tardigrade-ci project. i.e. `/<project>/` and
`/<project>/tardigrade-ci`.

* A parent/sibling directory of the current project. This allows a dev to
have a separate clone of tardigrade-ci in a parent/sibling directory,
for either local dev/test of tardigrade-ci, or just to reduce clone-sprawl
of tardigrade-ci. i.e. `/<project>/` and `/tardigrade-ci/`.

Previously, some weird behavior could occur with the docker/run target
in the second case. If the user had a local clone of tardigrade-ci (and
had not run `make init`), then the container did not have access to the
tardigrade-ci project, and so the 'include' for the tardigrade-ci/Makefile
would fail.