### PR TITLE
Authenticates to GitHub API with GITHUB_ACCESS_TOKEN only if present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ jobs:
     - stage: test
       name: Run Makefile unit tests
       script:
-        - docker build -t "$IMAGE_NAME" -f Dockerfile . && docker run "$IMAGE_NAME" bats/test
+        - docker build --build-arg GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN -t "$IMAGE_NAME" -f Dockerfile .
+        - docker run "$IMAGE_NAME" bats/test
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/tardigrade-ci
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### 0.8.0
 
-**Released**: 2021.01.11
+**Released**: 2021.01.12
 
 **Commit Delta**: [Change from 0.7.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.7.0...0.8.0)
 
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 *   Sets `docker/run` WORKDIR to `/workdir` and mounts calling project to `/workdir`
 *   Exposes the env `entrypoint` to the `docker/run` target, keeping backwards
     compatibility by setting the default to `make`
+*   Authenticates to GitHub API with GITHUB_ACCESS_TOKEN only if present
 
 ### 0.7.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.15.6-buster as golang
 FROM python:3.9.1-buster
 ARG PROJECT_NAME=tardigrade-ci
+ARG GITHUB_ACCESS_TOKEN
 ENV PATH="/root/.local/bin:/root/bin:/go/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
 RUN apt-get update -y && apt-get install -y \


### PR DESCRIPTION
GitHub has begun scanning for and disabling access tokens in committed, public code (even when readonly). This broke the prior mechanism of authenticating to the GitHub API to increase rate limits.

This patch will use GITHUB_ACCESS_TOKEN if it is present in the env. If not present, anonymous authentication will be used (which is subject to a lower rate limit).