### PR TITLE
Corrects a couple use cases when operating inside docker containers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.8.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.8.1
+
+**Released**: 2021.01.13
+
+**Commit Delta**: [Change from 0.8.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.8.0...0.8.1)
+
+**Summary**:
+
+*   Runs auto-init in non-`tardigrade-ci` containers, so the make targets are available
+*   Ensures `$PWD` is always set, including when invoking the container directly
+    with `docker run`
+
 ### 0.8.0
 
 **Released**: 2021.01.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,17 @@ ARG PROJECT_NAME=tardigrade-ci
 ARG GITHUB_ACCESS_TOKEN
 ENV PATH="/root/.local/bin:/root/bin:/go/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
+COPY --from=golang /go/ /go/
+COPY --from=golang /usr/local/go/ /usr/local/go/
+COPY . /${PROJECT_NAME}
 RUN apt-get update -y && apt-get install -y \
     xz-utils \
     curl \
     jq \
     unzip \
     make \
-&& rm -rf /var/lib/apt/lists/*
-COPY --from=golang /go/ /go/
-COPY --from=golang /usr/local/go/ /usr/local/go/
-COPY . /${PROJECT_NAME}
-RUN make -C /${PROJECT_NAME} install
+    && make -C /${PROJECT_NAME} install \
+    && touch /.dockerenv \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /${PROJECT_NAME}
 ENTRYPOINT ["make"]

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -1,4 +1,5 @@
 export SHELL = /bin/bash
+export PWD = $(shell pwd)
 export TARDIGRADE_CI_ORG ?= plus3it
 export TARDIGRADE_CI_PROJECT ?= tardigrade-ci
 export TARDIGRADE_CI_BRANCH ?= $(or $(shell grep 'FROM $(TARDIGRADE_CI_ORG)/$(TARDIGRADE_CI_PROJECT)' Dockerfile 2> /dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' 2> /dev/null),master)

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -28,9 +28,9 @@ endef
 # checkout does not match TARDIGRADE_CI_BRANCH
 define $(TARDIGRADE_CI_PROJECT)/init
 if [[ \
-	-f "/.dockerenv" \
+	-f "/.dockerenv" && -f "/$(TARDIGRADE_CI_PROJECT)/Makefile" \
 ]]; then \
-	echo "[bootstrap]: In docker container, skipping auto-init" ;\
+	echo "[bootstrap]: In $(TARDIGRADE_CI_PROJECT) docker container, skipping auto-init" ;\
 elif [[ \
 	"$(TARDIGRADE_CI_PATH)" != "$(TARDIGRADE_CI_PATH_LOCAL)" && \
 	-f "$(TARDIGRADE_CI_MAKEFILE)" \


### PR DESCRIPTION
* PWD is an env set by the shell. When invoked outside a shell, such as using `docker run`, PWD is not guaranteed to exist. This patch ensures PWD is set, which fixes use cases inside docker containers.

* When the project is using a build system (CodeBuild, travis-ci) that is itself running in a docker container, the file `.dockerenv` exists, so the auto-init was skipped. But these containers do not have the `/tardigrade-ci/` project contents, so `make` would fail to find any targets. Even calling `make init` explicitly would fail in this scenario. This patch ensures that auto-init will run in non-tardigrade-ci containers, so the targets will be available.

#### Testing guidance:

1. Setup a new project using this fork/branch:

```
mkdir test-project && cd test-project
git init
echo 'FROM plus3it/tardigrade-ci:0.8.0' > Dockerfile
echo 'include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/lorengordon/tardigrade-ci/docker-fix/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)' > Makefile
```

2. Pull a non-tardigrade-ci container:

```
docker pull python:3
```

3. Use the non-tardigrade-ci container to test the make targets:

```
docker run --rm -v $PWD:/workdir --workdir=/workdir --entrypoint make python:3 help
```

NOTE: Testing the `docker/run` target like this doesn't seem too feasible. Requires Docker-in-Docker. Maybe there is some way to do it, but I can't figure it out...