### PR TITLE
Fix .pylintrc handling and add support for pytest linting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1
+current_version = 0.9.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,5 +35,5 @@ indent_size = 1
 [LICENSE]
 indent_size = none
 
-[.pylintrc]
+[.*pylintrc]
 indent_size = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 *   PYLINT_RCFILE defines location of the .pylintrc used by pylint
 *   Loadable-plugin added to .pylintrc file to support pytest linting
-*   Unit test updated to support latest version of terraform-docs (0.11.0)
 
 ### 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.9.0
+
+**Released**: 2021.02.18
+
+**Commit Delta**: [Change from 0.8.1 release](https://github.com/plus3it/tardigrade-ci/compare/0.8.1...0.9.0)
+
+**Summary**:
+
+*   PYLINT_RCFILE defines location of the .pylintrc used by pylint
+*   Loadable-plugin added to .pylintrc file to support pytest linting
+*   Unit test updated to support latest version of terraform-docs (0.11.0)
+
 ### 0.8.1
 
 **Released**: 2021.01.13

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ guard/program/%:
 	@ which $* > /dev/null || $(MAKE) $*/install
 
 guard/python_pkg/%:
-	@ pip freeze | grep $* > /dev/null || $(MAKE) $*/install
+	@ $(PYTHON) -m pip freeze | grep $* > /dev/null || $(MAKE) $*/install
 
 $(BIN_DIR):
 	@ echo "[make]: Creating directory '$@'..."

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ MAKEFLAGS += --no-print-directory
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
+PYTHON ?= python3
+
 .PHONY: guard/% %/install %/lint
 
 DEFAULT_HELP_TARGET ?= help
@@ -66,6 +68,9 @@ guard/env/%:
 
 guard/program/%:
 	@ which $* > /dev/null || $(MAKE) $*/install
+
+guard/python_pkg/%:
+	@ pip freeze | grep $* > /dev/null || $(MAKE) $*/install
 
 $(BIN_DIR):
 	@ echo "[make]: Creating directory '$@'..."
@@ -124,7 +129,6 @@ ec/install:
 	@ echo "[$@]: Completed successfully!"
 
 install/pip/%: PKG_VERSION_CMD ?= $* --version
-install/pip/%: PYTHON ?= python3
 install/pip/%: | guard/env/PYPI_PKG_NAME
 	@ echo "[$@]: Installing $*..."
 	$(PYTHON) -m pip install --user $(PYPI_PKG_NAME)
@@ -132,11 +136,18 @@ install/pip/%: | guard/env/PYPI_PKG_NAME
 	$(PKG_VERSION_CMD)
 	@ echo "[$@]: Completed successfully!"
 
+install/pip_pkg_with_no_cli/%: | guard/env/PYPI_PKG_NAME
+	@ echo "[$@]: Installing $*..."
+	$(PYTHON) -m pip install --user $(PYPI_PKG_NAME)
+
 black/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
 
 pylint/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
+
+pylint-pytest/install:
+	@ $(MAKE) install/pip_pkg_with_no_cli/$(@D) PYPI_PKG_NAME=$(@D)
 
 pydocstyle/install:
 	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME=$(@D)
@@ -201,16 +212,19 @@ ec/lint:
 
 python/%: PYTHON_FILES ?= $(shell git ls-files --cached --others --exclude-standard '*.py')
 ## Checks format and lints Python files
-python/lint: | guard/program/pylint guard/program/black guard/program/pydocstyle guard/program/git
+python/lint: PYLINT_RCFILE ?= $(TARDIGRADE_CI_PATH)/.pylintrc
+python/lint: | guard/program/pylint guard/python_pkg/pylint-pytest guard/program/black guard/program/pydocstyle guard/program/git
 python/lint:
 	@ echo "[$@]: Linting Python files..."
+	@ echo "[$@]: Pylint rcfile:  $(PYLINT_RCFILE)"
 	black --check $(PYTHON_FILES)
 	for python_file in $(PYTHON_FILES); do \
-		pylint --msg-template="{path}:{line} [{symbol}] {msg}" \
+		$(PYTHON) -m pylint --rcfile $(PYLINT_RCFILE) \
+			--msg-template="{path}:{line} [{symbol}] {msg}" \
 			-rn -sn $$python_file; \
 	done
 	pydocstyle $(PYTHON_FILES)
-	echo "[$@]: Python files PASSED lint test!"
+	@ echo "[$@]: Python files PASSED lint test!"
 
 ## Formats Python files
 python/format: | guard/program/black guard/program/git
@@ -381,6 +395,6 @@ project/validate:
 	[ "$$(ls -A $(PWD))" ] || (echo "Project root folder is empty. Please confirm docker has been configured with the correct permissions" && exit 1)
 	@ echo "[$@]: Target test folder validation successful"
 
-install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install bumpversion/install
+install: terraform/install shellcheck/install terraform-docs/install bats/install black/install pylint/install pylint-pytest/install pydocstyle/install ec/install yamllint/install cfn-lint/install yq/install bumpversion/install
 
 lint: project/validate terraform/lint sh/lint json/lint docs/lint python/lint ec/lint cfn/lint hcl/lint

--- a/tests/make/.test_pylintrc
+++ b/tests/make/.test_pylintrc
@@ -317,7 +317,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=88
+max-line-length=20
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/tests/make/Makefile
+++ b/tests/make/Makefile
@@ -1,3 +1,4 @@
 export YAMLLINT_CONFIG := ../../.yamllint.yml
+export PYLINT_RCFILE := ../../.pylintrc
 
 -include ../../Makefile

--- a/tests/make/python_lint_pylint_rcfile_failure.bats
+++ b/tests/make/python_lint_pylint_rcfile_failure.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/python_lint_pylint_rcfile_failure"
+
+function setup() {
+rm -rf "$TEST_DIR"
+working_dirs=("$TEST_DIR" "$TEST_DIR/nested")
+for working_dir in "${working_dirs[@]}"
+do
+  mkdir -p "$working_dir"
+  cat > "$working_dir/test_long_line.py" <<"EOF"
+"""Pylintrc test."""
+print("Line is more than 20 characters long")
+EOF
+done
+}
+
+@test "python/lint rcfile: failure" {
+  # The test .pylintrc file specifies a line length of 20.
+  run make PYLINT_RCFILE="./.test_pylintrc" python/lint
+  [ "$status" -eq 2 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}

--- a/tests/make/python_lint_pylint_rcfile_success.bats
+++ b/tests/make/python_lint_pylint_rcfile_success.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/python_lint_pylint_rcfile_success"
+
+function setup() {
+rm -rf "$TEST_DIR"
+working_dirs=("$TEST_DIR" "$TEST_DIR/nested")
+for working_dir in "${working_dirs[@]}"
+do
+  mkdir -p "$working_dir"
+  cat > "$working_dir/test_good_length.py" <<"EOF"
+"""Test rcfile."""
+print("good len")
+EOF
+done
+}
+
+@test "python/lint rcfile: success" {
+  # The test .pylintrc file specifies a line length of 20.
+  run make PYLINT_RCFILE="./.test_pylintrc" python/lint
+
+  # If there are no pylint issues, there will be no pylint output.
+  [ "$status" -eq 0 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}


### PR DESCRIPTION
Depending how the makefile was run, it would not necessarily find `tardigrade-ci`'s `.pylintrc` file.  The location of the `.pylintrc` file is now specified by the variable `PYLINT_RCFILE` and by default it points to`tardigrade-ci`'s `.pylintrc`.

The `.pylintrc` file was updated to include the loadable plugin 'pylint-pytest' and there is now the capability to install python modules in addition to python scripts.