### PR TITLE
Pins terraform-docs to v0.10.1 to avoid requiring changes in every project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ terraform/install: | $(BIN_DIR) guard/program/jq
 	$(@D) --version
 	@ echo "[$@]: Completed successfully!"
 
-terraform-docs/install: TFDOCS_VERSION ?= latest
+terraform-docs/install: TFDOCS_VERSION ?= tags/v0.10.1
 terraform-docs/install: | $(BIN_DIR) guard/program/jq
 	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=segmentio REPO=$(@D) VERSION=$(TFDOCS_VERSION) QUERY='.name | endswith("$(OS)-$(ARCH)")'
 

--- a/tests/make/docs_lint_success.bats
+++ b/tests/make/docs_lint_success.bats
@@ -30,14 +30,6 @@ No requirements.
 
 No provider.
 
-## Modules
-
-No Modules.
-
-## Resources
-
-No resources.
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -47,6 +39,7 @@ No resources.
 ## Outputs
 
 No output.
+
 <!-- END TFDOCS -->
 EOF
 done


### PR DESCRIPTION
The latest version of terraform-docs, v0.11.x, introduces some changes to the readme sections. To avoid requiring changes to every project that uses tardigrade-ci, this patch temporarily pins the old version.