### PR TITLE
Skips setting AWS_PROFILE when the env is not available

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ docker/run: docker/build
 	-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/" \
 	-v "$(HOME)/.aws/:/root/.aws/" \
 	-e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
-	-e AWS_PROFILE=$(AWS_PROFILE) \
+	$(if $(AWS_PROFILE),-e AWS_PROFILE=$(AWS_PROFILE),) \
 	-e GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN) \
 	-w /workdir/ \
 	--entrypoint $(entrypoint) \


### PR DESCRIPTION
Previously, AWS_PROFILE would be set to a null value if the env was unset. That is an invalid configuration and could result in exceptions in AWS SDKs when they attempt to setup a session.