### PR TITLE
Uses latest terraform-docs, finishing with a single empty newline

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.1
+current_version = 0.9.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.9.2
+
+**Released**: 2021.02.19
+
+**Commit Delta**: [Change from 0.9.1 release](https://github.com/plus3it/tardigrade-ci/compare/0.9.1...0.9.2)
+
+**Summary**:
+
+*   Restores terraform-docs version to latest (currently v0.11.1), suppressing
+    the `modules` and `resources` sections. Also, the newline behavior of `docs/generate`
+    is managed explicitly so it is no longer subject to future changes in the
+    terminating newline behavior of `terraform-docs`. See [PR #143](https://github.com/plus3it/tardigrade-ci/pull/143)
+
+### 0.9.1
+
+**Released**: 2021.02.18
+
+**Commit Delta**: [Change from 0.9.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.9.0...0.9.1)
+
+**Summary**:
+
+*   Skips setting AWS_PROFILE when the env is not available
+
 ### 0.9.0
 
 **Released**: 2021.02.18

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ terraform/install: | $(BIN_DIR) guard/program/jq
 	$(@D) --version
 	@ echo "[$@]: Completed successfully!"
 
-terraform-docs/install: TFDOCS_VERSION ?= tags/v0.10.1
+terraform-docs/install: TFDOCS_VERSION ?= latest
 terraform-docs/install: | $(BIN_DIR) guard/program/jq
 	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=segmentio REPO=$(@D) VERSION=$(TFDOCS_VERSION) QUERY='.name | endswith("$(OS)-$(ARCH)")'
 
@@ -289,14 +289,14 @@ json/format: | guard/program/jq json/validate
 	$(FIND_JSON) | $(XARGS) bash -c 'echo "$$(jq --indent 4 -S . "{}")" > "{}"'
 	@ echo "[$@]: Successfully formatted JSON files!"
 
-docs/%: TFDOCS ?= terraform-docs --sort-by-required markdown table
+docs/%: TFDOCS ?= terraform-docs --hide modules --hide resources --sort-by-required markdown table
 docs/%: README_FILES ?= find . $(FIND_EXCLUDES) -type f -name README.md
 docs/%: README_TMP ?= $(TMP)/README.tmp
 docs/%: TFDOCS_START_MARKER ?= <!-- BEGIN TFDOCS -->
 docs/%: TFDOCS_END_MARKER ?= <!-- END TFDOCS -->
 
 docs/tmp/%: | guard/program/terraform-docs
-	@ sed '/$(TFDOCS_START_MARKER)/,/$(TFDOCS_END_MARKER)/{//!d}' $* | awk '{print $$0} /$(TFDOCS_START_MARKER)/ {system("$(TFDOCS) $$(dirname $*)")} /$(TFDOCS_END_MARKER)/ {f=1}' > $(README_TMP)
+	@ sed '/$(TFDOCS_START_MARKER)/,/$(TFDOCS_END_MARKER)/{//!d}' $* | awk '{print $$0} /$(TFDOCS_START_MARKER)/ {system("echo \"$$($(TFDOCS) $$(dirname $*))\"; echo")} /$(TFDOCS_END_MARKER)/ {f=1}' > $(README_TMP)
 
 docs/generate/%:
 	@ echo "[$@]: Creating documentation files.."


### PR DESCRIPTION
The prior version of terraform-docs left the trailing newline, so
that is what all our current docs have. The latest terraform-docs
trims all newlines from the end.

This isn't the first time terraform-docs has changed how it manages
terminating newline characters. This patch takes control of the newline
behavior by stripping all newlines, `echo "$(...)"`, and adding back
a single newline at the end, `; echo`. This way we match the current
tests and the readmes in all current projects, and we won't be subject
to future changes in terraform-docs and its behavior with terminating
newlines.

This patch also disables the "modules" and "resources" outputs of
terraform-docs v0.11.x, to avoid requiring further changes to project
readmes.