### PR TITLE
Allow additional type of tests to "make test" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,15 +366,17 @@ terratest/install: | guard/program/go
 	cd $(TERRAFORM_TEST_DIR) && go mod tidy
 	@ echo "[$@]: Completed successfully!"
 
+terratest/test: TERRATEST_FILES ?= $(shell find $(TERRAFORM_TEST_DIR) -name "*.go")
 terratest/test: | guard/program/go
 terratest/test: TIMEOUT ?= 20m
 terratest/test:
-	@ echo "[$@] Starting Terraform tests"
-	cd $(TERRAFORM_TEST_DIR) && go test -count=1 -timeout $(TIMEOUT)
+	@ echo "[$@] Starting Terratest-based Terraform tests"
+	$(if $(TERRATEST_FILES),\
+	cd $(TERRAFORM_TEST_DIR) && go test -count=1 -timeout $(TIMEOUT))
 	@ echo "[$@]: Completed successfully!"
 
 ## Runs terraform tests in the tests directory
-test: terratest/test
+test:: terratest/test
 
 bats/install: BATS_VERSION ?= latest
 bats/install:

--- a/tests/make/terraform_test_success.bats
+++ b/tests/make/terraform_test_success.bats
@@ -18,6 +18,11 @@ EOF
 @test "test: terraform test success" {
   run make TERRAFORM_TEST_DIR="../terraform" test
   [ "$status" -eq 0 ]
+
+  # Test for success when there are no go files.  Re-use the test directory
+  # that only contains terraform files.
+  run make TERRAFORM_TEST_DIR="../terraform/example_testcase" test
+  [ "$status" -eq 0 ]
 }
 
 function teardown() {


### PR DESCRIPTION
The `test` target is now additive:  A makefile including the `tardigrade-ci` makefile can now define a `test` target and the commands for that target will be executed in addition to `test` target commands in the included `tardigrade-ci` makefile.

Also fixed the `test` target so it does not attempt to execute `go test` if there are no `go` files.