### PR TITLE
Adds env that controls whether auto-init is enabled

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.11.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.11.0
+
+**Released**: 2021.03.19
+
+**Commit Delta**: [Change from 0.10.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.10.0...0.11.0)
+
+**Summary**:
+
+*   Adds env TARDIGRADE_CI_AUTO_INIT that controls whether auto-init is enabled
+    (defaults to true).
+*   Suppresses the duplicative output from the auto-init logic in recursive calls
+    to $(MAKE).
+
 ### 0.10.0
 
 **Released**: 2021.03.18

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ HELP_FILTER ?= .*
 TARDIGRADE_CI_PATH ?= $(PWD)
 TARDIGRADE_CI_PROJECT ?= tardigrade-ci
 
+export TARDIGRADE_CI_AUTO_INIT = false
+
 export SELF ?= $(MAKE)
 
 default:: $(DEFAULT_HELP_TARGET)

--- a/bootstrap/Makefile.bootstrap
+++ b/bootstrap/Makefile.bootstrap
@@ -9,6 +9,7 @@ TARDIGRADE_CI_PATH ?= $(shell until [ -d "$(TARDIGRADE_CI_PROJECT)" ] || [ "`pwd
 TARDIGRADE_CI_PATH_LOCAL := $(PWD)/$(TARDIGRADE_CI_PROJECT)
 TARDIGRADE_CI_BOOTSTRAP := $(PWD)/.$(TARDIGRADE_CI_PROJECT)
 TARDIGRADE_CI_CLONE_URL ?= https://github.com/$(TARDIGRADE_CI_ORG)/$(TARDIGRADE_CI_PROJECT).git
+TARDIGRADE_CI_AUTO_INIT ?= true
 
 # Resolves to TARDIGRADE_CI_PATH_LOCAL when TARDIGRADE_CI_PATH does not exist
 export TARDIGRADE_CI_PATH := $(or $(wildcard $(TARDIGRADE_CI_PATH)),$(TARDIGRADE_CI_PATH_LOCAL))
@@ -48,7 +49,7 @@ else \
 fi
 endef
 
-include $(shell $($(TARDIGRADE_CI_PROJECT)/init) >&2 ; echo $(TARDIGRADE_CI_MAKEFILE))
+include $(if $(findstring true,$(TARDIGRADE_CI_AUTO_INIT)),$(shell $($(TARDIGRADE_CI_PROJECT)/init) >&2)) $(TARDIGRADE_CI_MAKEFILE)
 
 .PHONY : init
 ## Init build-harness


### PR DESCRIPTION
Also suppresses the auto-init output in recursive calls to $(MAKE).
The workflow is:

1. The bootstrap sets TARDIGRADE_CI_AUTO_INIT = true
2. The bootstrap include statement executes the auto-init macro, outputs
   status accordingly, and includes the tardigrade-ci Makefile
3. The tardigrade-ci Makefile *exports* TARDIGRADE_CI_AUTO_INIT = false
4. Recursive calls to $(MAKE) include the bootstrap again
5. The bootstrap include disables the auto-init macro because
   TARDIGRADE_CI_AUTO_INIT != true