### PR TITLE
Extracts terraform-docs from archive retrieved from github release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.1
+current_version = 0.12.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.12.2
+
+**Released**: 2021.05.03
+
+**Commit Delta**: [Change from 0.12.1 release](https://github.com/plus3it/tardigrade-ci/compare/0.12.1..0.12.2)
+
+**Summary**:
+
+*   Provides a macro "stream_github_release" that supports piping a GitHub Release
+    artifact to another tool (like `tar`). The target "stream/gh-release/%" is
+    deprecated in favor of this macro, to avoid an unnecessary recursive `$(MAKE)`.
+*   Updates the `terraform-docs/install` target to extract the binary from the
+    tar.gz archive hosted by GitHub Releases, as the binary is no longer available
+    as a separate artifact.
+
 ### 0.12.1
 
 **Released**: 2021.05.3
@@ -12,13 +27,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 **Summary**:
 
-* Remove the "--user" option from the "python -m pip install" commands. 
+*   Remove the "--user" option from the "python -m pip install" commands.
 
 ### 0.12.0
 
 **Released**: 2021.04.23
 
-**Commit Delta**: [Change from 0.12.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.11.0..0.12.0)
+**Commit Delta**: [Change from 0.11.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.11.0..0.12.0)
 
 **Summary**:
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,10 @@ terraform/install: | $(BIN_DIR) guard/program/jq
 
 terraform-docs/install: TFDOCS_VERSION ?= latest
 terraform-docs/install: | $(BIN_DIR) guard/program/jq
-	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=segmentio REPO=$(@D) VERSION=$(TFDOCS_VERSION) QUERY='.name | endswith("$(OS)-$(ARCH)")'
+	@ echo "[$@]: Installing $(@D)..."
+	$(call stream_github_release,$(@D),$(@D),$(TFDOCS_VERSION),.name | endswith("$(OS)-$(ARCH).tar.gz")) | tar -C "$(BIN_DIR)" -xzv --wildcards --no-anchored $(@D)
+	$(@D) --version
+	@ echo "[$@]: Completed successfully!"
 
 jq/install: JQ_VERSION ?= latest
 jq/install: | $(BIN_DIR)


### PR DESCRIPTION
The terraform-docs team is no longer providing the binary as its own release artifact. It is now only available within a tar.gz archive.