### PR TITLE
Correct pydocstyle unit test for new version of black

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.2
+current_version = 0.12.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.12.3
+
+**Released**: 2021.05.04
+
+**Commit Delta**: [Change from 0.12.2 release](https://github.com/plus3it/tardigrade-ci/compare/0.12.2..0.12.3)
+
+**Summary**:
+
+*   Updates version of black. Modifies pydocstyle unit test to accommodate change for the new version of black.
+
 ### 0.12.2
 
 **Released**: 2021.05.03

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,10 @@ OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:'])
 CURL ?= curl --fail -sSL
 XARGS ?= xargs -I {}
 BIN_DIR ?= ${HOME}/bin
-PIP_BIN_DIR ?= ${HOME}/.local/bin
 TMP ?= /tmp
 FIND_EXCLUDES ?= -not \( -name .terraform -prune \) -not \( -name .terragrunt-cache -prune \)
 
-PATH := $(BIN_DIR):$(PIP_BIN_DIR):${PATH}
+PATH := $(BIN_DIR):${PATH}
 
 MAKEFLAGS += --no-print-directory
 SHELL := bash
@@ -142,6 +141,7 @@ install/pip/%: PKG_VERSION_CMD ?= $* --version
 install/pip/%: | $(BIN_DIR) guard/env/PYPI_PKG_NAME
 	@ echo "[$@]: Installing $*..."
 	$(PYTHON) -m pip install $(PYPI_PKG_NAME)
+	ln -sf ~/.local/bin/$* $(BIN_DIR)/$*
 	$(PKG_VERSION_CMD)
 	@ echo "[$@]: Completed successfully!"
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:'])
 CURL ?= curl --fail -sSL
 XARGS ?= xargs -I {}
 BIN_DIR ?= ${HOME}/bin
+PIP_BIN_DIR ?= ${HOME}/.local/bin
 TMP ?= /tmp
 FIND_EXCLUDES ?= -not \( -name .terraform -prune \) -not \( -name .terragrunt-cache -prune \)
 
-PATH := $(BIN_DIR):${PATH}
+PATH := $(BIN_DIR):$(PIP_BIN_DIR):${PATH}
 
 MAKEFLAGS += --no-print-directory
 SHELL := bash
@@ -141,7 +142,6 @@ install/pip/%: PKG_VERSION_CMD ?= $* --version
 install/pip/%: | $(BIN_DIR) guard/env/PYPI_PKG_NAME
 	@ echo "[$@]: Installing $*..."
 	$(PYTHON) -m pip install $(PYPI_PKG_NAME)
-	ln -sf ~/.local/bin/$* $(BIN_DIR)/$*
 	$(PKG_VERSION_CMD)
 	@ echo "[$@]: Completed successfully!"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Keep this list in alphabetical order, with a single blank line between each package
 
-black==20.8b1
+black==21.4b2
 
 bumpversion==0.6.0
 

--- a/tests/make/python_lint_pydocstyle_failure.bats
+++ b/tests/make/python_lint_pydocstyle_failure.bats
@@ -18,7 +18,7 @@ import os
 
 
 def testing():
-    """This should print the current OS name """
+    """This should print the current OS name"""
 
     print(os.name)
 EOF


### PR DESCRIPTION
black now detects an error before pydocstyle is run, so the pydocstyle unit test fails with the newer version of black.