### PR TITLE
Fails the test when the build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 env:
   global:
-    - IMAGE_NAME=plus3it/tardigrade-ci
+    - IMAGE_NAME=tardigrade-ci-test
 
 if: branch = master OR type = pull_request OR tag is present
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,10 @@ jobs:
       script: make sh/lint
     - stage: test
       name: Run Makefile unit tests
-      script:
-        - docker build --build-arg GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN -t "$IMAGE_NAME" -f Dockerfile .
-        - docker run "$IMAGE_NAME" bats/test
+      script: |
+        set -e
+        docker build --build-arg GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN -t "$IMAGE_NAME" -f Dockerfile .
+        docker run "$IMAGE_NAME" bats/test
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/tardigrade-ci
       before_script:


### PR DESCRIPTION
Previously, if `docker build` failed, `docker run` would pull the latest image from dockerhub. That meant the bats/test would run on the wrong image.

This patch ensures that the test fails when the build fails, and for good measure also changes the image name in the test so it can't be pulled from dockerhub.