### PR TITLE
Bumps version to 0.14.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.14.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.14.1
+
+**Released**: 2021.07.9
+
+**Commit Delta**: [Change from 0.14.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.14.0..0.14.1)
+
+**Summary**:
+
+*   Updates language versions:
+    * python 3.9.6
+*   Updates tool versions:
+    * black 21.6b0
+    * cfn-lint 0.52.0
+    * pylint 2.9.3
+    * terraform 1.0.2
+    * terraform-docs 0.14.1
+    * terragrunt 0.31.0
+    * terratest 0.36.5
+    * yq 4.9.8
+
 ### 0.14.0
 
 **Released**: 2021.05.28


### PR DESCRIPTION
Comparison from 0.14.0 release to current master: https://github.com/plus3it/tardigrade-ci/compare/0.14.0...master

This release is necessary as a result of a transitory dependency in cfn-lint, the `networkx` library. The networkx 2.6 release is incompatible with cfn-lint 0.50.0, currently what is released in tardigrade-ci 0.14.0. Using cfn-lint 0.50.0 and networkx 2.6.1 results in:

```
$ cfn-lint --version
Traceback (most recent call last):
  File "/home/loren/.local/bin/cfn-lint", line 5, in <module>
    from cfnlint.__main__ import main
  File "/home/loren/.local/lib/python3.9/site-packages/cfnlint/__init__.py", line 9, in <module>
    from cfnlint.graph import Graph
  File "/home/loren/.local/lib/python3.9/site-packages/cfnlint/graph.py", line 10, in <module>
    from networkx import networkx
ImportError: cannot import name 'networkx' from 'networkx' (/home/loren/.local/lib/python3.9/site-packages/networkx/__init__.py)
```

Upgrading to cfn-lint 0.52.0 fixes it:

```
$ python3.9 -m pip install --upgrade cfn-lint
Installing collected packages: cfn-lint
  Attempting uninstall: cfn-lint
    Found existing installation: cfn-lint 0.50.0
    Uninstalling cfn-lint-0.50.0:
      Successfully uninstalled cfn-lint-0.50.0
Successfully installed cfn-lint-0.52.0

$ cfn-lint --version
cfn-lint 0.52.0
```
