### PR TITLE
Update pytest targets

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.0
+current_version = 0.16.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.16.0
+
+**Released**: 2021.07.22
+
+**Commit Delta**: [Change from 0.15.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.15.0..0.16.0)
+
+**Summary**:
+
+*   Adds the target "pytest/%" for Python unit testing.
+
+*   Replaces the environment variable TERRAFORM_PYTEST_ARGS with PYTEST_ARGS.
+
+*   Corrects an error with the integration test utility that occurs when 
+    Terraform fails during the apply.
+
+*   No changes to tool versions.
+
 ### 0.15.0
 
 **Released**: 2021.07.15

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -30,13 +30,13 @@ be located in the directory `tests` off the repo\'s root directory.
 | Environment variable             | Default value |
 | -------------------------------- | --------------------------------------- |
 | INTEGRATION_TEST_BASE_IMAGE_NAME | $(basename $PWD)-integration-test |
-| TERRAFORM_PYTEST_ARGS            | |
+| PYTEST_ARGS                      | |
 | TERRAFORM_PYTEST_DIR             | $PWD/tests/terraform/pytest |
 
 ### Arguments to the automation script
 
 These are values that can be specified through the environment variable
-TERRAFORM_PYTEST_ARGS.
+PYTEST_ARGS.
 
 | Command line option | Description |
 | ------------------- | ----------------------------------------------- |
@@ -84,7 +84,7 @@ make terraform/pytest
 # option also allows booleans, e.g., "not" or "or".
 #
 # The following will match on the subdirectory "create_groups".
-make terraform/pytest TERRAFORM_PYTEST_ARGS="-k groups"
+make terraform/pytest PYTEST_ARGS="-k groups"
 
 # When testing is complete:
 make mockstack/clean

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -67,6 +67,13 @@ subdirectory.  For example:
 ...
 ```
 
+The `prereq` approach solves the problem where the top-level module has a
+count/for_each dependency on the supporting resources being created in
+the test.  It creates two terraform state files, one for the prereq and
+one for the test config. The approach here is just a way of separating
+the supporting resources from the test module, but they are all in the
+same terraform state.
+
 To verify that a Terraform test will work, bring up the default AWS mock
 stack (`LocalStack`) first, then execute the test:
 
@@ -83,6 +90,22 @@ make terraform/pytest TERRAFORM_PYTEST_ARGS="-k groups"
 
 # When testing is complete:
 make mockstack/clean
+```
+
+Alternatively, in lieu of running `make mockstack/up`, LocalStack can be
+run from the command line in a separate window. This will provide you with
+a running log (although you could view the docker log (with no debugging)
+when using `make mockstack/up`).
+
+```
+pip install localstack
+
+# Most of the AWS services are started here, but the list can be tailored
+# to just the ones needed for the test.
+DEBUG=1 SERVICES=ec2,iam,sts,s3,kms,cloudformation,cloudwatch,events,lambda,route53,ssm,sns,sqs,glue,dynamodb localstack start
+
+# Wait for a LocalStack to issue the "Ready" message before starting a test.
+# To exit LocalStack, type Ctrl-C.
 ```
 
 ## Potential CI/CD changes 

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -70,9 +70,7 @@ subdirectory.  For example:
 The `prereq` approach solves the problem where the top-level module has a
 count/for_each dependency on the supporting resources being created in
 the test.  It creates two terraform state files, one for the prereq and
-one for the test config. The approach here is just a way of separating
-the supporting resources from the test module, but they are all in the
-same terraform state.
+one for the test config.
 
 To verify that a Terraform test will work, bring up the default AWS mock
 stack (`LocalStack`) first, then execute the test:

--- a/Makefile
+++ b/Makefile
@@ -280,10 +280,11 @@ python/format:
 	@ echo "[$@]: Successfully formatted Python files!"
 
 # Run pytests, typically for unit tests.
+pytest/%: PYTEST_ARGS ?=
 pytest/%: | guard/program/pytest
 pytest/%:
-	@ echo "[$@] Starting Python tests"
-	pytest $*
+	@ echo "[$@] Starting Python tests found under the directory \"$*\""
+	pytest $* $(PYTEST_ARGS)
 	@ echo "[$@]: Tests executed!"
 
 ## Lints terraform files

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,13 @@ python/format:
 	black $(PYTHON_FILES)
 	@ echo "[$@]: Successfully formatted Python files!"
 
+# Run pytests, typically for unit tests.
+pytest/%: | guard/program/pytest
+pytest/%:
+	@ echo "[$@] Starting Python tests"
+	pytest $*
+	@ echo "[$@]: Tests executed!"
+
 ## Lints terraform files
 terraform/lint: | guard/program/terraform
 	@ echo "[$@]: Linting Terraform files..."

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,8 @@ terratest/test:
 	@ echo "[$@]: Completed successfully!"
 
 TERRAFORM_PYTEST_DIR ?= $(TARDIGRADE_CI_PATH)/tests/terraform_pytest
-terraform/pytest: | guard/program/terraform guard/python_pkg/tftest pytest/$(TERRAFORM_PYTEST_DIR)
+terraform/pytest: | guard/program/terraform guard/python_pkg/tftest
+terraform/pytest: | pytest/$(TERRAFORM_PYTEST_DIR)
 
 .PHONY: mockstack/pytest mockstack/up mockstack/down mockstack/clean
 INTEGRATION_TEST_BASE_IMAGE_NAME ?= $(shell basename $(PWD))-integration-test

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ python/format:
 	@ echo "[$@]: Successfully formatted Python files!"
 
 # Run pytests, typically for unit tests.
-pytest/%: PYTEST_ARGS ?=
+PYTEST_ARGS ?=
 pytest/%: | guard/program/pytest
 pytest/%:
 	@ echo "[$@] Starting Python tests found under the directory \"$*\""
@@ -428,19 +428,15 @@ terratest/test:
 	cd $(TERRAFORM_TEST_DIR) && go test -count=1 -timeout $(TIMEOUT)
 	@ echo "[$@]: Completed successfully!"
 
-TERRAFORM_PYTEST_ARGS ?=
 TERRAFORM_PYTEST_DIR ?= $(TARDIGRADE_CI_PATH)/tests/terraform_pytest
-terraform/pytest: | guard/program/terraform guard/program/pytest guard/python_pkg/tftest
-	@ echo "[$@] Starting Terraform integration test"
-	pytest -v $(TERRAFORM_PYTEST_DIR) $(TERRAFORM_PYTEST_ARGS)
-	@ echo "[$@]: Completed successfully!"
+terraform/pytest: | guard/program/terraform guard/python_pkg/tftest pytest/$(TERRAFORM_PYTEST_DIR)
 
 .PHONY: mockstack/pytest mockstack/up mockstack/down mockstack/clean
 INTEGRATION_TEST_BASE_IMAGE_NAME ?= $(shell basename $(PWD))-integration-test
 mockstack/%: MOCKSTACK ?= localstack
 mockstack/pytest:
 	@ echo "[$@] Running Terraform tests against LocalStack"
-	DOCKER_RUN_FLAGS="--network terraform_pytest_default --rm -e MOCKSTACK_HOST=$(MOCKSTACK) -e TERRAFORM_PYTEST_ARGS=$(TERRAFORM_PYTEST_ARGS)" \
+	DOCKER_RUN_FLAGS="--network terraform_pytest_default --rm -e MOCKSTACK_HOST=$(MOCKSTACK) -e PYTEST_ARGS=\"$(PYTEST_ARGS)\"" \
 		IMAGE_NAME=$(INTEGRATION_TEST_BASE_IMAGE_NAME):latest \
 		$(MAKE) docker/run target=terraform/pytest
 	@ echo "[$@]: Completed successfully!"

--- a/tests/make/pytest_failure.bats
+++ b/tests/make/pytest_failure.bats
@@ -23,7 +23,6 @@ EOF
 @test "pytest: failure" {
   run make pytest/$TEST_DIR
   [ "$status" -eq 2 ]
-  echo $output
   [[ "$output" == *"assert 3 == 4"* ]]
   [[ "$output" == *"FAILED"* ]]
 }

--- a/tests/make/pytest_failure.bats
+++ b/tests/make/pytest_failure.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/pytest_failure"
+
+# Generate a simple pytest where the test fails.
+function setup() {
+rm -rf "$TEST_DIR"
+working_dir="$TEST_DIR"
+mkdir -p "$working_dir"
+
+cat > "$working_dir/bad_test.py" <<"EOF"
+"""Simple test of pytest."""
+def inc(x):
+    """Return x + 1."""
+    return x + 1
+
+def test_answer():
+    """Test of inc(x)."""
+    assert inc(2) == 4
+EOF
+}
+
+@test "pytest: failure" {
+  run make pytest/$TEST_DIR
+  [ "$status" -eq 2 ]
+  echo $output
+  [[ "$output" == *"assert 3 == 4"* ]]
+  [[ "$output" == *"FAILED"* ]]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}

--- a/tests/make/pytest_success.bats
+++ b/tests/make/pytest_success.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+TEST_DIR="$(pwd)/pytest_success"
+
+# Generate a simple pytest where the test succeeds.
+function setup() {
+rm -rf "$TEST_DIR"
+working_dir="$TEST_DIR"
+mkdir -p "$working_dir"
+
+cat > "$working_dir/good_test.py" <<"EOF"
+"""Simple test of pytest."""
+def inc(x):
+    """Return x + 1."""
+    return x + 1
+
+def test_answer():
+    """Test of inc(x)."""
+    assert inc(2) == 3
+EOF
+}
+
+@test "pytest: success" {
+  run make pytest/$TEST_DIR
+  [ "$status" -eq 0 ]
+}
+
+function teardown() {
+  rm -rf "$TEST_DIR"
+}

--- a/tests/make/terraform_pytest_failure.bats
+++ b/tests/make/terraform_pytest_failure.bats
@@ -33,7 +33,7 @@ EOF
 }
 
 @test "test: terraform pytest failure" {
-  run make terraform/pytest TERRAFORM_PYTEST_DIR=../terraform_pytest TERRAFORM_PYTEST_ARGS="--tf-dir $TEST_DIR"
+  run make terraform/pytest TERRAFORM_PYTEST_DIR=../terraform_pytest PYTEST_ARGS="-v --tf-dir $TEST_DIR"
   [ "$status" -eq 2 ]
   [[ "$output" == *"FAILED ../terraform_pytest/test_terraform_install.py::test_modules[test]"* ]]
 }

--- a/tests/make/terraform_pytest_success.bats
+++ b/tests/make/terraform_pytest_success.bats
@@ -22,7 +22,7 @@ done
 }
 
 @test "test: terraform pytest success" {
-  run make terraform/pytest TERRAFORM_PYTEST_DIR=../terraform_pytest TERRAFORM_PYTEST_ARGS="--tf-dir $TEST_DIR"
+  run make terraform/pytest TERRAFORM_PYTEST_DIR=../terraform_pytest PYTEST_ARGS="-v --tf-dir $TEST_DIR"
   [ "$status" -eq 0 ]
   [[ "$output" == *"test_modules[test] PASSED [100%]"* ]]
 }

--- a/tests/terraform_pytest/mockstack.tf
+++ b/tests/terraform_pytest/mockstack.tf
@@ -28,6 +28,7 @@ provider "aws" {
     ssm              = "http://${var.mockstack_host}:${var.mockstack_port}"
     stepfunctions    = "http://${var.mockstack_host}:${var.mockstack_port}"
     sts              = "http://${var.mockstack_host}:${var.mockstack_port}"
+
     configservice    = "http://${var.mockstack_host}:${var.moto_port}"
   }
 }

--- a/tests/terraform_pytest/test_terraform_install.py
+++ b/tests/terraform_pytest/test_terraform_install.py
@@ -56,6 +56,7 @@ def test_modules(subdir, monkeypatch, tf_test_object, tf_vars):
     """Run plan/apply against a Terraform module found in tests subdir."""
     monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_DEFAULT_REGION)
 
+    tf_test = None
     prereq_tf_test = None
     try:
         # Run the Terraform module in "prereq" before executing the test
@@ -75,6 +76,7 @@ def test_modules(subdir, monkeypatch, tf_test_object, tf_vars):
     finally:
         # Destroy the resources for the module under test, then destroy the
         # "prereq" resources, if a "prereq" subdirectory exists.
-        tf_test.destroy(tf_vars=tf_vars)
+        if tf_test:
+            tf_test.destroy(tf_vars=tf_vars)
         if prereq_tf_test:
             prereq_tf_test.destroy(tf_vars=tf_vars)


### PR DESCRIPTION
Adds the new target "pytest/%" and fixes an error in the integration test utility that occurs when a test fails.