### PR TITLE
Lint all in Travis workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.0
+current_version = 0.16.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
   include:
     - stage: lint
       name: Project Syntax Verification
+      install: make install
       script: make lint
     - stage: test
       name: Run Makefile unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
-dist: bionic
+dist: focal
 
-language: node_js
-
-node_js:
-  - "12"
+language: minimal
 
 env:
   global:
@@ -22,11 +19,8 @@ services:
 jobs:
   include:
     - stage: lint
-      name: EditorConfig Syntax Verification
-      script: make ec/lint
-    - stage: lint
-      name: Shell Script Syntax Verification
-      script: make sh/lint
+      name: Project Syntax Verification
+      script: make lint
     - stage: test
       name: Run Makefile unit tests
       install: docker build --build-arg GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN -t "$IMAGE_NAME" -f Dockerfile .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.16.1
+
+**Released**: 2021.07.22
+
+**Commit Delta**: [Change from 0.16.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.16.0..0.16.1)
+
+**Summary**:
+
+*   Modifies Travis workflow to run lint generically, not just ec and a shell check.
+
+*   Corrects various lint errors.
+
+*   No changes to tool versions.
+
 ### 0.16.0
 
 **Released**: 2021.07.22

--- a/tests/terraform_pytest/mockstack.tf
+++ b/tests/terraform_pytest/mockstack.tf
@@ -29,7 +29,7 @@ provider "aws" {
     stepfunctions    = "http://${var.mockstack_host}:${var.mockstack_port}"
     sts              = "http://${var.mockstack_host}:${var.mockstack_port}"
 
-    configservice    = "http://${var.mockstack_host}:${var.moto_port}"
+    configservice = "http://${var.mockstack_host}:${var.moto_port}"
   }
 }
 


### PR DESCRIPTION
The Travis workflow only specified specific lints, ec and shell linting.  With a previous change for recursive Terraform linting, this meant Terraform lint errors in tardigrade-ci files weren't caught until after a new version of tardigrade-ci was released and a repo using that version contained Terraform files.

The Travis workflow will now perform a `make lint` to perform all lints that it currently handles.