### PR TITLE
Creates a non-root user in docker image and passes user context when building image

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.1
+current_version = 0.17.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.17.0
+
+**Released**: 2021.07.29
+
+**Commit Delta**: [Change from 0.16.1 release](https://github.com/plus3it/tardigrade-ci/compare/0.16.1..0.17.0)
+
+**Summary**:
+
+*   Creates a non-root user in docker image and passes user context when
+    building the image. This ensures that files created in volumes mounted to
+    the docker container are owned by the user running the container.
+*   Mounts the `.aws` directory as read-only in the docker container.
+
 ### 0.16.1
 
 **Released**: 2021.07.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,36 @@ FROM python:3.9.6-buster
 
 ARG PROJECT_NAME=tardigrade-ci
 ARG GITHUB_ACCESS_TOKEN
-ENV PATH="/root/.local/bin:/root/bin:/go/bin:/usr/local/go/bin:${PATH}"
-ENV GOPATH=/go
-COPY --from=golang /go/ /go/
+
+ARG USER=${PROJECT_NAME}
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Things to do as root
+USER root
+RUN addgroup --gid ${USER_GID} ${USER} \
+    && adduser --disabled-password --gecos '' --uid ${USER_UID} --gid ${USER_GID} ${USER}
+
 COPY --from=golang /usr/local/go/ /usr/local/go/
-COPY . /${PROJECT_NAME}
+
 RUN apt-get update -y && apt-get install -y \
     xz-utils \
     curl \
     jq \
     unzip \
     make \
-    && make -C /${PROJECT_NAME} install \
     && touch /.dockerenv \
     && rm -rf /var/lib/apt/lists/*
+
+# Things to do as $USER
+USER ${USER}
+
+ENV PATH="/${USER}/.local/bin:/${USER}/bin:/go/bin:/usr/local/go/bin:${PATH}"
+ENV GOPATH=/go
+
+COPY --chown=${USER}:${USER} --from=golang /go/ /go/
+COPY --chown=${USER}:${USER} . /${PROJECT_NAME}
+RUN make -C /${PROJECT_NAME} install
+
 WORKDIR /${PROJECT_NAME}
 ENTRYPOINT ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y && apt-get install -y \
 # Things to do as $USER
 USER ${USER}
 
-ENV PATH="/${USER}/.local/bin:/${USER}/bin:/go/bin:/usr/local/go/bin:${PATH}"
+ENV PATH="/home/${USER}/.local/bin:/home/${USER}/bin:/go/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
 
 COPY --chown=${USER}:${USER} --from=golang /go/ /go/

--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,7 @@ docker/build:
 	@echo "[$@]: building docker image named: $(IMAGE_NAME)"
 	[ -n "$(IMAGE_ID)" ] && echo "[$@]: Image already present: $(IMAGE_ID)" || \
 	$(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) \
+		--build-arg PROJECT_NAME=$(TARDIGRADE_CI_PROJECT) \
 		--build-arg USER_UID=$$(id -u) \
 		--build-arg USER_GID=$$(id -g) \
 		-f $(TARDIGRADE_CI_DOCKERFILE) .
@@ -401,7 +402,7 @@ docker/run: docker/build
 	docker run $(DOCKER_RUN_FLAGS) \
 	-v "$(PWD)/:/workdir/" \
 	-v "$(TARDIGRADE_CI_PATH)/:/$(TARDIGRADE_CI_PROJECT)/" \
-	-v "$(HOME)/.aws/:/root/.aws/" \
+	-v "$(HOME)/.aws/:/home/$(TARDIGRADE_CI_PROJECT)/.aws/:ro" \
 	-e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
 	$(if $(AWS_PROFILE),-e AWS_PROFILE=$(AWS_PROFILE),) \
 	-e GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN) \

--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,8 @@ docker/build:
 	@echo "[$@]: building docker image named: $(IMAGE_NAME)"
 	[ -n "$(IMAGE_ID)" ] && echo "[$@]: Image already present: $(IMAGE_ID)" || \
 	$(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) \
-		--build-arg USER_ID=$$(id -u) \
-		--build-arg GROUP_ID=$$(id -g) \
+		--build-arg USER_UID=$$(id -u) \
+		--build-arg USER_GID=$$(id -g) \
 		-f $(TARDIGRADE_CI_DOCKERFILE) .
 	@echo "[$@]: Docker image build complete"
 

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,10 @@ docker/build: DOCKER_BUILDKIT ?= $(shell [ -z $(TRAVIS) ] && echo "DOCKER_BUILDK
 docker/build:
 	@echo "[$@]: building docker image named: $(IMAGE_NAME)"
 	[ -n "$(IMAGE_ID)" ] && echo "[$@]: Image already present: $(IMAGE_ID)" || \
-	$(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) -f $(TARDIGRADE_CI_DOCKERFILE) .
+	$(DOCKER_BUILDKIT) docker build -t $(IMAGE_NAME) \
+		--build-arg USER_ID=$$(id -u) \
+		--build-arg GROUP_ID=$$(id -g) \
+		-f $(TARDIGRADE_CI_DOCKERFILE) .
 	@echo "[$@]: Docker image build complete"
 
 # Adds the current Makefile working directory as a bind mount


### PR DESCRIPTION
Prior to this patch, files created in the docker volume mounts were
owned by root, which causes permissions issues when accessing those
files outside the container.

This was particularly evident when running the mockstack/pytest target
(which operates inside the container), followed by running the terraform/pytest
target (which operates outside the container).

With this patch, files created in the mounted filesystem will be owned by
the user running the docker container, so there should no longer be
any permissions issues.