### PR TITLE
Uses fixuid in entrypoint to fix permissions issues with bindmounts

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.0
+current_version = 0.17.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # Keep these sorted alphabetically by <user>/<repo>, separated by an empty line
 
+      - uses: boxboat/fixuid@v0.5.1
+
       - uses: gruntwork-io/terragrunt@v0.31.1
 
       - uses: stedolan/jq@jq-1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.17.1
+
+**Released**: 2021.07.30
+
+**Commit Delta**: [Change from 0.17.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.17.0..0.17.1)
+
+**Summary**:
+
+*   Uses fixuid in entrypoint to fix permissions issues with bindmounts.
+    The user that builds the tardigrade-ci container and the user that runs
+    the tardigrade-ci container (or containers built from it) must have the
+    same UID, or permissions issues will occur. Fixuid checks the user running
+    the container and chowns any file or directory owned by a specified user/group
+    in its configuration. This ensures the user has permissions to those files
+    and directories.
+
 ### 0.17.0
 
 **Released**: 2021.07.29

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@ ARG USER_GID=${USER_UID}
 
 # Things to do as root
 USER root
-RUN addgroup --gid ${USER_GID} ${USER} \
-    && adduser --disabled-password --gecos '' --uid ${USER_UID} --gid ${USER_GID} ${USER}
-
-COPY --from=golang /usr/local/go/ /usr/local/go/
 
 RUN apt-get update -y && apt-get install -y \
     xz-utils \
@@ -25,15 +21,29 @@ RUN apt-get update -y && apt-get install -y \
     && touch /.dockerenv \
     && rm -rf /var/lib/apt/lists/*
 
+RUN addgroup --gid ${USER_GID} ${USER} \
+    && adduser --disabled-password --gecos '' --uid ${USER_UID} --gid ${USER_GID} ${USER}
+
+COPY --from=golang /usr/local/go/ /usr/local/go/
+COPY --chown=${USER}:${USER} --from=golang /go/ /go/
+COPY --chown=${USER}:${USER} . /${PROJECT_NAME}
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN make -C /${PROJECT_NAME} fixuid/install \
+    && cp /root/bin/fixuid /usr/local/bin/fixuid \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid\
+    && mkdir -p /etc/fixuid \
+    && printf "user: $USER\ngroup: $USER\n" > /etc/fixuid/config.yml
+
 # Things to do as $USER
 USER ${USER}
 
-ENV PATH="/home/${USER}/.local/bin:/home/${USER}/bin:/go/bin:/usr/local/go/bin:${PATH}"
+ENV HOME="/home/${USER}"
+ENV PATH="/${HOME}/.local/bin:/${HOME}/bin:/go/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
 
-COPY --chown=${USER}:${USER} --from=golang /go/ /go/
-COPY --chown=${USER}:${USER} . /${PROJECT_NAME}
 RUN make -C /${PROJECT_NAME} install
 
 WORKDIR /${PROJECT_NAME}
-ENTRYPOINT ["make"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ echo "[entrypoint.sh]: Running fixuid"
 fixuid -q
 
 echo "[entrypoint.sh]: Running make ${*}"
-make $*
+make "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu -o pipefail
+
+echo "[entrypoint.sh]: Running fixuid"
+fixuid -q
+
+echo "[entrypoint.sh]: Running make ${*}"
+make $*


### PR DESCRIPTION
The user that builds the tardigrade-ci container and the user that runs
the tardigrade-ci container (or containers built from it) must have the
same UID, or permissions issues will occur.

This patch uses fixuid in the tardigrade-ci entrypoint to fix this
issue. Fixuid checks the user running the container and chowns any
file or directory owned by a specified user/group in its configuration.
This ensures the user has permissions to those files and directories.