### PR TITLE
Add option to only use moto ports when testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.19.0
+
+**Released**: 2021.10.25
+
+**Commit Delta**: [Change from 0.18.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.18.0..0.19.0)
+
+**Summary**:
+
+*   The new environment variable "ONLY_MOTO" can be used to specify that
+    moto should be used for mock AWS services, and not LocalStack or some
+    combination of moto and LocalStack.
+
+* Updates tool versions:
+    * black 21.9.b0
+    * cfn-lint 0.54.2
+    * pylint 2.11.1
+    * pytest 6.2.5
+    * terraform 1.0.9
+    * terraform-docs 1.16.0
+    * terragrunt 0.35.3
+    * terratest 0.38.2
+    * yq 4.13.4
+    * Docker now using golang:1.17.2-buster
+    * Docker now using python:3.10.0-buster
+
 ### 0.18.0
 
 **Released**: 2021.09.13
@@ -21,18 +46,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
     by moto and not LocalStack.
 
 *   Updates tool versions:
-    * black 21.9b0
-    * cfn-lint 0.54.1
-    * pylint 2.11.1
-    * pytest 6.2.5
-    * terragrunt 0.31.10
-    * terraform 1.0.7
+    * cfn-lint 0.53.0
+    * pylint 2.10.2
+    * terraform 1.0.5
     * terraform-docs 0.15.0
-    * terratest 0.37.8
-    * yamllint 1.26.3
-    * yq 4.13.2
-    * Docker now using golang:1.17.1-buster
-    * Docker now using python:3.9.7-buster
+    * terragrunt 0.31.5
+    * terratest 0.37.7
+    * yamlint 1.26.3
+    * yq 4.12.0
+    * Docker now using golang:1.17.0-buster
 
 ### 0.17.1
 

--- a/Makefile
+++ b/Makefile
@@ -290,10 +290,11 @@ python/format:
 # Run pytests, typically for unit tests.
 PYTEST_ARGS ?=
 PYTEST_ALIAS_ARG ?= $(if $(PROVIDER_ALIAS),--alias $(PROVIDER_ALIAS),)
+PYTEST_ONLY_MOTO_ARG ?= $(if $(ONLY_MOTO),--only-moto,)
 pytest/%: | guard/program/pytest
 pytest/%:
 	@ echo "[$@] Starting Python tests found under the directory \"$*\""
-	pytest $* $(PYTEST_ARGS) $(PYTEST_ALIAS_ARG)
+	pytest $* $(PYTEST_ARGS) $(PYTEST_ALIAS_ARG) $(PYTEST_ONLY_MOTO_ARG)
 	@ echo "[$@]: Tests executed!"
 
 ## Lints terraform files

--- a/tests/terraform_pytest/conftest.py
+++ b/tests/terraform_pytest/conftest.py
@@ -28,6 +28,11 @@ def pytest_addoption(parser):
         action="store",
         help="Name of Terraform provider alias to include in test",
     )
+    parser.addoption(
+        "--only-moto",
+        action="store_true",
+        help="Only use moto ports for mock AWS services",
+    )
 
 
 @pytest.fixture(scope="function")
@@ -80,6 +85,9 @@ def is_mock(request, aws_credentials):
 
     if request.config.option.alternate_profile:
         pytest.exit(msg="conflicting options: 'alternate_profile' and 'nomock'")
+    elif request.config.option.only_moto:
+        pytest.exit(msg="conflicting options: 'only_moto' and 'nomock'")
+
     return False
 
 
@@ -96,6 +104,12 @@ def tf_dir(request):
 def provider_alias(request):
     """Return name of alias for provider, if one was given."""
     return request.config.getoption("--alias")
+
+
+@pytest.fixture(scope="session")
+def only_moto(request):
+    """Return True if only moto ports are to be used for mock services."""
+    return request.config.option.only_moto
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/terraform_pytest/test_terraform_install.py
+++ b/tests/terraform_pytest/test_terraform_install.py
@@ -59,7 +59,7 @@ def tf_test_object(is_mock, provider_alias, tf_dir, tmp_path):
 
 
 @pytest.fixture(scope="function")
-def tf_vars(is_mock):
+def tf_vars(is_mock, only_moto):
     """Return values for variables used for the Terraform apply.
 
     Set the Terraform variables for the hostname and port to differentiate
@@ -68,7 +68,7 @@ def tf_vars(is_mock):
     return (
         {
             "mockstack_host": MOCKSTACK_HOST,
-            "mockstack_port": MOCKSTACK_PORT,
+            "mockstack_port": MOTO_PORT if only_moto else MOCKSTACK_PORT,
             "moto_port": MOTO_PORT,
         }
         if is_mock


### PR DESCRIPTION
Provides an environment variable `ONLY_MOTO` that when set to "true", will add the `--only-moto` option to `PYTEST_ARGS`.  The `--only-moto` option ensures that only moto ports, and not LocalStack ports, will be used for the integration tests.