### PR TITLE
Add moto-only support for additional services

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.0
+current_version = 0.19.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.19.1
+
+**Released**: 2021.11.01
+
+**Commit Delta**: [Change from 0.19.0 release](https://github.com/plus3it/tardigrade-ci/compare/0.19.0..0.19.1)
+
+**Summary**:
+
+*   Added moto-only services to mockstack.tf:  Cloudtrail, Directory Service, 
+    Route53 and Route53 Resolver.
+
+* Updates tool versions:
+    * black 21.10b0
+    * cfn-lint 0.54.4
+    * terraform 1.0.10
+    * yq 4.14.1
+    * terragrunt 0.35.5
+
 ### 0.19.0
 
 **Released**: 2021.10.25

--- a/tests/terraform_pytest/mockstack.tf
+++ b/tests/terraform_pytest/mockstack.tf
@@ -29,6 +29,9 @@ provider "aws" {
     stepfunctions    = "http://${var.mockstack_host}:${var.mockstack_port}"
     sts              = "http://${var.mockstack_host}:${var.mockstack_port}"
 
-    firehose = "http://${var.mockstack_host}:${var.moto_port}"
+    cloudtrail      = "http://${var.mockstack_host}:${var.moto_port}"
+    ds              = "http://${var.mockstack_host}:${var.moto_port}"
+    firehose        = "http://${var.mockstack_host}:${var.moto_port}"
+    route53resolver = "http://${var.mockstack_host}:${var.moto_port}"
   }
 }

--- a/tests/terraform_pytest/mockstack.tf
+++ b/tests/terraform_pytest/mockstack.tf
@@ -32,6 +32,7 @@ provider "aws" {
     cloudtrail      = "http://${var.mockstack_host}:${var.moto_port}"
     ds              = "http://${var.mockstack_host}:${var.moto_port}"
     firehose        = "http://${var.mockstack_host}:${var.moto_port}"
+    route53         = "http://${var.mockstack_host}:${var.moto_port}"
     route53resolver = "http://${var.mockstack_host}:${var.moto_port}"
   }
 }

--- a/tests/terraform_pytest/mockstack.tf
+++ b/tests/terraform_pytest/mockstack.tf
@@ -18,7 +18,6 @@ provider "aws" {
     kinesis          = "http://${var.mockstack_host}:${var.mockstack_port}"
     kms              = "http://${var.mockstack_host}:${var.mockstack_port}"
     lambda           = "http://${var.mockstack_host}:${var.mockstack_port}"
-    route53          = "http://${var.mockstack_host}:${var.mockstack_port}"
     redshift         = "http://${var.mockstack_host}:${var.mockstack_port}"
     s3               = "http://${var.mockstack_host}:${var.mockstack_port}"
     secretsmanager   = "http://${var.mockstack_host}:${var.mockstack_port}"


### PR DESCRIPTION
Specifically, the following services were added to `mockstack.tf`:

- Cloudtrail
- Directory Services
- Route53 Resolver

Route53 was changed to use a moto port rather than a LocalStack port.