### PR TITLE
Issue warning if PYTEST_ARGS --only-moto and --nomock used

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.2
+current_version = 0.19.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.19.3
+
+**Released**: 2021.11.04
+
+**Commit Delta**: [Change from 0.19.2 release](https://github.com/plus3it/tardigrade-ci/compare/0.19.2..0.19.3)
+
+**Summary**:
+
+*   If ONLY_MOTO is set to true in a Makefile and a integration test is run
+    against AWS itself (versus a mock AWS), instead of failing due to the
+    conflicting command line options, a warning will be printed.
+
 ### 0.19.2
 
 **Released**: 2021.11.03

--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -44,7 +44,7 @@ PYTEST_ARGS.
 
 | Command line option | Description |
 | ------------------- | ----------------------------------------------- |
-| --nomock            | Use AWS, not mocked AWS services |
+| --nomock            | Use AWS, not mocked AWS services.  Takes precedence over the "--only-moto" option. |
 | --alias ALIAS       | Add a provider ALIAS to the Terraform test |
 | --alternate-profile | Configure an alternate profile in addition to default profile |
 | --only-moto         | Use moto ports only for mock AWS services |

--- a/tests/terraform_pytest/conftest.py
+++ b/tests/terraform_pytest/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures and command line processing for testing Terraform installation."""
 from pathlib import Path
+import warnings
 
 import pytest
 
@@ -86,7 +87,7 @@ def is_mock(request, aws_credentials):
     if request.config.option.alternate_profile:
         pytest.exit(msg="conflicting options: 'alternate_profile' and 'nomock'")
     elif request.config.option.only_moto:
-        pytest.exit(msg="conflicting options: 'only_moto' and 'nomock'")
+        warnings.warn(UserWarning("Ignoring command line option: 'only_moto'"))
 
     return False
 


### PR DESCRIPTION
Previously the use of both of these options would cause an exit.