### PR TITLE
Add MOTO_DOCKER_NETWORK_NAME to docker compose file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.3
+current_version = 0.19.4
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 * Updates tool versions:
     * black 21.12b0
     * cfn-lint 0.56.3
-    * golang 1.17.4-buster
+    * golang 1.17.5-buster
     * pylint 2.12.2
+    * python 3.10.1-buster
     * shellcheck 0.8.0
-    * terraform 1.0.11
-    * terragrunt 0.35.13
+    * terraform 1.1.0
+    * terragrunt 0.35.14
     * terratest 0.38.6
     * tftest 1.6.1
     * yq 4.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.19.4
+
+**Released**: 2021.12.13
+
+**Commit Delta**: [Change from 0.19.3 release](https://github.com/plus3it/tardigrade-ci/compare/0.19.3..0.19.4)
+
+**Summary**:
+
+*   Adds the environment variable MOTO_DOCKER_NETWORK_NAME to the docker
+    compose file used for LocalStack and moto.  This environment variable 
+    is used by moto_server to determine the IP address for the docker 
+    container.
+
+* Updates tool versions:
+    * black 21.12b0
+    * cfn-lint 0.56.3
+    * golang 1.17.4-buster
+    * pylint 2.12.2
+    * shellcheck 0.8.0
+    * terraform 1.0.11
+    * terragrunt 0.35.13
+    * terratest 0.38.6
+    * tftest 1.6.1
+    * yq 4.16.1
+
 ### 0.19.3
 
 **Released**: 2021.11.04

--- a/tests/terraform_pytest/docker-compose-localstack.yml
+++ b/tests/terraform_pytest/docker-compose-localstack.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - MAIN_CONTAINER_NAME=localstack
       - LAMBDA_DOCKER_NETWORK=terraform_pytest_default
+      - MOTO_DOCKER_NETWORK_NAME=terraform_pytest_default
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "${TERRAFORM_PYTEST_DIR}/initaws.d:/docker-entrypoint-initaws.d"


### PR DESCRIPTION
MOTO_DOCKER_NETWORK_NAME has been added to the list of environment variables passed to LocalStack in the `docker-compose-localstack.yml` file.  This environment variable is used by moto to determine the network IP address for `moto_server` when running in a docker container.