### PR TITLE
Allows callers to use any name for the Makefile, set with `make -f`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.1
+current_version = 0.21.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.21.2
+
+**Released**: 2022.01.26
+
+**Commit Delta**: [Change from 0.20.1 release](https://github.com/plus3it/tardigrade-ci/compare/0.20.1..0.21.2)
+
+**Summary**:
+
+* Allows callers to use any name for the Makefile, set with `make -f`.
+
 ### 0.21.1
 
 **Released**: 2022.01.20

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 ARCH ?= amd64
 OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:'])
 CURL ?= curl --fail -sSL
@@ -33,7 +34,7 @@ SEMVER_PATTERN ?= [0-9]+(\.[0-9]+){1,3}
 
 export TARDIGRADE_CI_AUTO_INIT = false
 
-export SELF ?= $(MAKE)
+export SELF ?= $(MAKE) -f $(THIS_MAKEFILE)
 
 default:: $(DEFAULT_HELP_TARGET)
 	@exit 0
@@ -86,10 +87,10 @@ guard/env/%:
 	@ _="$(or $($*),$(error Make/environment variable '$*' not present))"
 
 guard/program/%:
-	@ which $* > /dev/null || $(MAKE) $*/install
+	@ which $* > /dev/null || $(SELF) $*/install
 
 guard/python_pkg/%:
-	@ $(PYTHON) -m pip freeze | grep $* > /dev/null || $(MAKE) $*/install
+	@ $(PYTHON) -m pip freeze | grep $* > /dev/null || $(SELF) $*/install
 
 $(BIN_DIR):
 	@ echo "[make]: Creating directory '$@'..."
@@ -143,7 +144,7 @@ terraform/install: | $(BIN_DIR) guard/program/jq
 
 terragrunt/install: TERRAGRUNT_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_GITHUB_TOOLS),'gruntwork-io/terragrunt','$(SEMVER_PATTERN)')
 terragrunt/install: | $(BIN_DIR) guard/program/jq
-	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=gruntwork-io REPO=$(@D) VERSION=$(TERRAGRUNT_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
+	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=gruntwork-io REPO=$(@D) VERSION=$(TERRAGRUNT_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
 
 terraform-docs/install: TFDOCS_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_TOOLS),'terraform-docs/terraform-docs','$(SEMVER_PATTERN)')
 terraform-docs/install: | $(BIN_DIR) guard/program/jq
@@ -154,7 +155,7 @@ terraform-docs/install: | $(BIN_DIR) guard/program/jq
 
 jq/install: JQ_VERSION ?= tags/jq-$(call match_pattern_in_file,$(TARDIGRADE_CI_GITHUB_TOOLS),'stedolan/jq','$(SEMVER_PATTERN)')
 jq/install: | $(BIN_DIR)
-	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=stedolan REPO=$(@D) VERSION=$(JQ_VERSION) QUERY='.name | endswith("$(OS)64")'
+	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=stedolan REPO=$(@D) VERSION=$(JQ_VERSION) QUERY='.name | endswith("$(OS)64")'
 
 shellcheck/install: SHELLCHECK_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_TOOLS),'koalaman/shellcheck','$(SEMVER_PATTERN)')
 shellcheck/install: $(BIN_DIR) guard/program/xz
@@ -195,42 +196,42 @@ fixuid/install: | $(BIN_DIR) guard/program/jq
 
 docker-compose/install: DOCKER_COMPOSE_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'docker-compose==','$(SEMVER_PATTERN)')
 docker-compose/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(DOCKER_COMPOSE_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(DOCKER_COMPOSE_VERSION)'
 
 black/install: BLACK_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'black==','[0-9]+\.[0-9]+(b[0-9]+)?')
 black/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(BLACK_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(BLACK_VERSION)'
 
 pytest/install:
 	@ $(PIP) install -r $(TERRAFORM_PYTEST_DIR)/requirements.txt
 
 pylint/install: PYLINT_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'pylint==','$(SEMVER_PATTERN)')
 pylint/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(PYLINT_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(PYLINT_VERSION)'
 
 pylint-pytest/install: PYLINT_PYTEST_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'pylint-pytest==','$(SEMVER_PATTERN)')
 pylint-pytest/install:
-	@ $(MAKE) install/pip_pkg_with_no_cli/$(@D) PYPI_PKG_NAME='$(@D)==$(PYLINT_PYTEST_VERSION)'
+	@ $(SELF) install/pip_pkg_with_no_cli/$(@D) PYPI_PKG_NAME='$(@D)==$(PYLINT_PYTEST_VERSION)'
 
 pydocstyle/install: PYDOCSTYLE_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'pydocstyle==','$(SEMVER_PATTERN)')
 pydocstyle/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(PYDOCSTYLE_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(PYDOCSTYLE_VERSION)'
 
 yamllint/install: YAMLLINT_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'yamllint==','$(SEMVER_PATTERN)')
 yamllint/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(YAMLLINT_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(YAMLLINT_VERSION)'
 
 cfn-lint/install: CFN_LINT_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'cfn-lint==','$(SEMVER_PATTERN)')
 cfn-lint/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(CFN_LINT_VERSION)'
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(CFN_LINT_VERSION)'
 
 yq/install: YQ_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_TOOLS),'mikefarah/yq','$(SEMVER_PATTERN)')
 yq/install:
-	@ $(MAKE) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=mikefarah REPO=$(@D) VERSION=$(YQ_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
+	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=mikefarah REPO=$(@D) VERSION=$(YQ_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
 
 bump2version/install: BUMPVERSION_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_PYTHON_TOOLS),'bump2version==','$(SEMVER_PATTERN)')
 bump2version/install:
-	@ $(MAKE) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(BUMPVERSION_VERSION)' PKG_VERSION_CMD="bumpversion -h | grep 'bumpversion: v'"
+	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(BUMPVERSION_VERSION)' PKG_VERSION_CMD="bumpversion -h | grep 'bumpversion: v'"
 
 bumpversion/install: bump2version/install
 
@@ -454,7 +455,7 @@ mockstack/pytest:
 	@ echo "[$@] Running Terraform tests against LocalStack"
 	DOCKER_RUN_FLAGS="--network terraform_pytest_default --rm -e MOCKSTACK_HOST=$(MOCKSTACK) -e PYTEST_ARGS=\"$(PYTEST_ARGS)\"" \
 		IMAGE_NAME=$(INTEGRATION_TEST_BASE_IMAGE_NAME):latest \
-		$(MAKE) docker/run target=terraform/pytest
+		$(SELF) docker/run target=terraform/pytest
 	@ echo "[$@]: Completed successfully!"
 
 mockstack/up:


### PR DESCRIPTION
Previously, if a caller named their tardigrade-ci makefile any non-default
name, e.g. Makefile.foo, while also having a default-named makefile, e.g. Makefile,
and invoked `make -f Makefile.foo`, the sub-makes would invoke the default
makefile and not the tardigrade-ci makefile.

This patch updates all sub-make calls to specify the file to use with
make. This is accomplished by determing the current Makefile:

```
THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
```

And then updating the SELF variable to `$(MAKE) -f $(THIS_MAKEFILE)`.
All sub-makes are modifed to use the updated `$(SELF)` variable instead
of directly using `$(MAKE)`.

This allows a caller to name their tardigrade-ci makefile anything,
e.g. Makefile.foo, and call all the targets using `make -f Makefile.foo`.