### PR TITLE
Standardizes all "find" logic using "git ls-files" to honor .gitignore

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.9
+current_version = 0.22.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 0.22.0
+
+**Released**: 2022.08.23
+
+**Commit Delta**: [Change from 0.21.9 release](https://github.com/plus3it/tardigrade-ci/compare/0.21.9..0.22.0)
+
+**Summary**:
+
+* Replaces all "find" logic with `git ls-files` to honor `.gitignore` by default
+    * Patterns for FIND_EXCLUDES will now need to be based on the git pathspec (e.g. `':!:*/.terraform/*'`), instead of `find`. See also, <https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec>
+    * ECLINT_FILES now takes the command that returns the files, and not the list of files
+    * All FIND_* variables can now be overriden by providing the command that returns the files
+
+* Updates tool versions:
+    * cfn-lint 0.61.5
+    * golang 1.19.0
+    * localstack 1.0.4
+    * packer 1.8.3
+    * pylint 2.14.5
+    * python 3.10.6
+    * rclone 1.59.1
+    * terraform 1.2.7
+    * terragrunt 0.38.7
+    * terratest 0.40.19
+    * tftest 1.7.1
+    * yq 4.27.2
+
 ### 0.21.9
 
 **Released**: 2022.07.14

--- a/tests/make/ec_lint_success.bats
+++ b/tests/make/ec_lint_success.bats
@@ -19,7 +19,7 @@ done
 
 @test "ec/lint: success" {
   # The 'ec/lint' Makefile target excludes *.bats files.
-  ECLINT_FILES=$(find "${TEST_DIR}" -type f | xargs echo)
+  ECLINT_FILES="find ${TEST_DIR} -type f | xargs echo"
 
   run make ec/lint ECLINT_FILES="${ECLINT_FILES}"
   [ "$status" -eq 0 ]

--- a/tests/make/json_format_failure.bats
+++ b/tests/make/json_format_failure.bats
@@ -15,7 +15,7 @@ EOF
 @test "json/format: nested file failure" {
   run make json/format
   [ "$status" -eq 2 ]
-  [[ "$output" == *"[./json_format_failure/top/failure.json]: Found invalid JSON file: ./json_format_failure/top/failure.json"* ]]
+  [[ "$output" == *"[json_format_failure/top/failure.json]: Found invalid JSON file: json_format_failure/top/failure.json"* ]]
 }
 
 function teardown() {


### PR DESCRIPTION
Link to see changes on master compared to last release: https://github.com/plus3it/tardigrade-ci/compare/0.21.9...master