### PR TITLE
Uses specs bundled with cfn-lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 * Provides make target to install pyenv, and adds pyenv to docker image
 * Uses pyenv to install Python 3.8 to the docker image
 * Eliminates check whether to rebuild image, relying on docker change detection
+* Uses specs bundled with cfn-lint
 
 * Updates tool versions:
     * bats 1.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,7 @@ ENV PYENV_ROOT=${HOME}/.pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:${HOME}/.local/bin:${HOME}/bin:/go/bin:/usr/local/go/bin:${PATH}"
 ENV GOPATH=/go
 
-RUN make -C /${PROJECT_NAME} install \
-    && cfn-lint --update-specs
+RUN make -C /${PROJECT_NAME} install
 
 # Install python versions
 RUN pyenv install ${PYTHON_38_VERSION} \


### PR DESCRIPTION
The update takes a very long time and quite a bit of space, and the reason we added the update in the first place is no longer relevant. The version of cfn-lint has the necessary specs for all our templates.