### PR TITLE
Reads tool versions from mise.toml instead of dependabot hack

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.2
+current_version = 0.29.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -18,12 +18,8 @@ on:
 jobs:
   dependabot_hack:
     name: Track project/tool versions with Dependabot
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      # Keep these sorted alphabetically by <user>/<repo>, separated by an empty line
+      - run: echo "This workflow is only for Dependabot to track versions of tools. It should never be triggered manually or by other workflows." && exit 1
 
-      - uses: astral-sh/uv@0.11.3
-
-      - uses: gruntwork-io/terragrunt@0.99.5
-
-      - uses: stedolan/jq@jq-1.8.1
+      # Keep tools below sorted alphabetically by <user>/<repo>, separated by an empty line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [0.29.3](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.3)
+
+**Released**: 2026.04.07
+
+**Summary**:
+
+* Reads tool versions from mise.toml instead of dependabot hack
+* Updates tool versions:
+    * cfn-lint 1.48.1
+    * tftest 1.8.7
+    * uv 0.11.3
+
 ### [0.29.2](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.2)
 
 **Released**: 2026.04.03

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ export TARDIGRADE_CI_DOCKERFILE_PYTHON312 ?= $(TARDIGRADE_CI_PATH)/.github/depen
 export TARDIGRADE_CI_DOCKERFILE_PYTHON313 ?= $(TARDIGRADE_CI_PATH)/.github/dependencies/python313/Dockerfile
 export TARDIGRADE_CI_DOCKERFILE_PYTHON314 ?= $(TARDIGRADE_CI_PATH)/.github/dependencies/python314/Dockerfile
 export TARDIGRADE_CI_GITHUB_TOOLS ?= $(TARDIGRADE_CI_PATH)/.github/workflows/dependabot_hack.yml
+export TARDIGRADE_CI_MISE_TOOLS ?= $(TARDIGRADE_CI_PATH)/mise.toml
 export TARDIGRADE_CI_PYTHON_TOOLS ?= $(TARDIGRADE_CI_PATH)/requirements.txt
 export SEMVER_PATTERN ?= [0-9]+(\.[0-9]+){1,3}
 
@@ -168,7 +169,7 @@ terraform/install: | $(BIN_DIR) guard/program/jq
 	$(@D) --version
 	@ echo "[$@]: Completed successfully!"
 
-terragrunt/install: export TERRAGRUNT_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_GITHUB_TOOLS),'gruntwork-io/terragrunt','$(SEMVER_PATTERN)')
+terragrunt/install: export TERRAGRUNT_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE_CI_MISE_TOOLS),'terragrunt = ','$(SEMVER_PATTERN)')
 terragrunt/install: | $(BIN_DIR) guard/program/jq
 	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=gruntwork-io REPO=$(@D) VERSION=$(TERRAGRUNT_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
 
@@ -179,7 +180,7 @@ terraform-docs/install: | $(BIN_DIR) guard/program/jq
 	$(@D) --version
 	@ echo "[$@]: Completed successfully!"
 
-jq/install: export JQ_VERSION ?= tags/jq-$(call match_pattern_in_file,$(TARDIGRADE_CI_GITHUB_TOOLS),'stedolan/jq','$(SEMVER_PATTERN)')
+jq/install: export JQ_VERSION ?= tags/jq-$(call match_pattern_in_file,$(TARDIGRADE_CI_MISE_TOOLS),'jq = ','$(SEMVER_PATTERN)')
 jq/install: | $(BIN_DIR)
 	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=stedolan REPO=$(@D) VERSION=$(JQ_VERSION) QUERY='.name | endswith("$(OS)64")'
 
@@ -316,7 +317,7 @@ yq/install: export YQ_VERSION ?= tags/v$(call match_pattern_in_file,$(TARDIGRADE
 yq/install:
 	@ $(SELF) install/gh-release/$(@D) FILENAME="$(BIN_DIR)/$(@D)" OWNER=mikefarah REPO=$(@D) VERSION=$(YQ_VERSION) QUERY='.name | endswith("$(OS)_$(ARCH)")'
 
-uv/%: export UV_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_GITHUB_TOOLS),'astral-sh/uv@[0-9]','$(SEMVER_PATTERN)')
+uv/%: export UV_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_MISE_TOOLS),'uv = ','$(SEMVER_PATTERN)')
 uv/version:
 	@ echo $(UV_VERSION)
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+jq = "1.8.1"
+terragrunt = "1.0.0"
+uv = "0.11.3"


### PR DESCRIPTION
This stops dependabot from reading the _branch_ `5.4.1` on gruntwork/terragrunt as a terragrunt version, and proposing an updating to version 5.4.1. 🙄 

Instead, dependabot will read the version from mise.toml, and will use the mise sources to lookup available release versions. Mise doesn't read from github _branches_ for version or ref info, so avoids the same problem.