### PR TITLE
Uses metadata embedded in uv release to get latest available python versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.3
+current_version = 0.29.4
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.github/dependencies/python312/Dockerfile
+++ b/.github/dependencies/python312/Dockerfile
@@ -1,8 +1,0 @@
-# This Dockerfile is used to let Dependabot manage the pinned version of Python 3.12
-# that will be installed into the docker container.
-
-# This file is separate from the other Dockerfile tools in order to create a separate
-# entry in the Dependabot config that ignores major and minor version updates, in
-# order to keep this pinned to Python 3.12.
-
-FROM python:3.12.13 as python312

--- a/.github/dependencies/python313/Dockerfile
+++ b/.github/dependencies/python313/Dockerfile
@@ -1,8 +1,0 @@
-# This Dockerfile is used to let Dependabot manage the pinned version of Python 3.13
-# that will be installed into the docker container.
-
-# This file is separate from the other Dockerfile tools in order to create a separate
-# entry in the Dependabot config that ignores major and minor version updates, in
-# order to keep this pinned to Python 3.13.
-
-FROM python:3.13.12 as python313

--- a/.github/dependencies/python314/Dockerfile
+++ b/.github/dependencies/python314/Dockerfile
@@ -1,8 +1,0 @@
-# This Dockerfile is used to let Dependabot manage the pinned version of Python 3.14
-# that will be installed into the docker container.
-
-# This file is separate from the other Dockerfile tools in order to create a separate
-# entry in the Dependabot config that ignores major and minor version updates, in
-# order to keep this pinned to Python 3.14.
-
-FROM python:3.14.3 as python314

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [0.29.4](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.4)
+
+**Released**: 2026.04.15
+
+**Summary**:
+
+* Uses metadata embedded in uv release to get latest available python versions
+* Updates tool versions:
+    * pytest 9.0.3
+    * python-hcl2 8.1.1
+    * rclone 1.73.4
+
 ### [0.29.3](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.3)
 
 **Released**: 2026.04.07

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,6 @@ export PWD := $(shell pwd)
 export TARDIGRADE_CI_PATH ?= $(PWD)
 export TARDIGRADE_CI_PROJECT ?= tardigrade-ci
 export TARDIGRADE_CI_DOCKERFILE_TOOLS ?= $(TARDIGRADE_CI_PATH)/Dockerfile.tools
-export TARDIGRADE_CI_DOCKERFILE_PYTHON312 ?= $(TARDIGRADE_CI_PATH)/.github/dependencies/python312/Dockerfile
-export TARDIGRADE_CI_DOCKERFILE_PYTHON313 ?= $(TARDIGRADE_CI_PATH)/.github/dependencies/python313/Dockerfile
-export TARDIGRADE_CI_DOCKERFILE_PYTHON314 ?= $(TARDIGRADE_CI_PATH)/.github/dependencies/python314/Dockerfile
 export TARDIGRADE_CI_GITHUB_TOOLS ?= $(TARDIGRADE_CI_PATH)/.github/workflows/dependabot_hack.yml
 export TARDIGRADE_CI_MISE_TOOLS ?= $(TARDIGRADE_CI_PATH)/mise.toml
 export TARDIGRADE_CI_PYTHON_TOOLS ?= $(TARDIGRADE_CI_PATH)/requirements.txt
@@ -224,7 +221,8 @@ black/install: export BLACK_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE
 black/install:
 	@ $(SELF) install/pip/$(@D) PYPI_PKG_NAME='$(@D)==$(BLACK_VERSION)'
 
-python312/%: export PYTHON_312_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_PYTHON312),'python:3.12','$(SEMVER_PATTERN)')
+python312/%: | guard/program/uv
+python312/%: export PYTHON_312_VERSION ?= $(shell uv python list 3.12 --only-downloads --output-format json | jq -r '.[0].version')
 
 python312/install:
 	@ $(SELF) install/uv-python/$(PYTHON_312_VERSION)
@@ -238,7 +236,8 @@ python312/venv:
 python312/version:
 	@ echo $(PYTHON_312_VERSION)
 
-python313/%: export PYTHON_313_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_PYTHON313),'python:3.13','$(SEMVER_PATTERN)')
+python313/%: | guard/program/uv
+python313/%: export PYTHON_313_VERSION ?= $(shell uv python list 3.13 --only-downloads --output-format json | jq -r '.[0].version')
 
 python313/install:
 	@ $(SELF) install/uv-python/$(PYTHON_313_VERSION)
@@ -252,7 +251,8 @@ python313/venv:
 python313/version:
 	@ echo $(PYTHON_313_VERSION)
 
-python314/%: export PYTHON_314_VERSION ?= $(call match_pattern_in_file,$(TARDIGRADE_CI_DOCKERFILE_PYTHON314),'python:3.14','$(SEMVER_PATTERN)')
+python314/%: | guard/program/uv
+python314/%: export PYTHON_314_VERSION ?= $(shell uv python list 3.14 --only-downloads --output-format json | jq -r '.[0].version')
 
 python314/install:
 	@ $(SELF) install/uv-python/$(PYTHON_314_VERSION)


### PR DESCRIPTION
Comparison link for checking updated tool versions: https://github.com/plus3it/tardigrade-ci/compare/0.29.3...master