### PR TITLE
Merge mock aws provider config into all discovered aws provider configs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.4
+current_version = 0.29.5
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [0.29.5](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.5)
+
+**Released**: 2026.05.11
+
+**Summary**:
+
+* Merge mock aws provider config into all discovered aws provider
+* Map podman userns to container user 1001
+* Updates tool versions:
+    * cfn-lint 1.50.1
+    * moto 5.2.0
+    * packer 1.15.3
+    * python-hcl2 8.1.2
+    * rclone 1.74.0
+    * terraform 1.15.2
+    * yq 4.53.2
+
+
 ### [0.29.4](https://github.com/plus3it/tardigrade-ci/releases/tag/0.29.4)
 
 **Released**: 2026.04.15

--- a/Makefile
+++ b/Makefile
@@ -545,6 +545,7 @@ docker/run: export AWS_DEFAULT_REGION ?= us-east-1
 docker/run: export target ?= help
 docker/run: export entrypoint ?= entrypoint.sh
 docker/run: export DOCKER_USERNS ?=
+docker/run: export PODMAN_USERNS ?= keep-id:uid=1001,gid=1001
 docker/run: | guard/env/TARDIGRADE_CI_PATH guard/env/TARDIGRADE_CI_PROJECT
 	@ echo "[$@]: Checking the image '$(IMAGE_NAME)' exists..."
 	@ if docker image inspect $(IMAGE_NAME) > /dev/null 2>&1; \
@@ -556,7 +557,7 @@ docker/run: | guard/env/TARDIGRADE_CI_PATH guard/env/TARDIGRADE_CI_PROJECT
 	fi
 	@ echo "[$@]: Running target "$(target)"..."
 	userns=""; \
-	if docker --version 2>/dev/null | grep -qi podman; then userns="--userns=keep-id"; elif [ -n "$(DOCKER_USERNS)" ]; then userns="--userns=$(DOCKER_USERNS)"; fi; \
+	if docker --version 2>/dev/null | grep -qi podman; then userns="--userns=$(PODMAN_USERNS)"; elif [ -n "$(DOCKER_USERNS)" ]; then userns="--userns=$(DOCKER_USERNS)"; fi; \
 	docker run $(DOCKER_RUN_FLAGS) \
 	$$userns \
 	-v "$(PWD)/:/workdir/" \

--- a/tests/terraform_pytest/test_terraform_install.py
+++ b/tests/terraform_pytest/test_terraform_install.py
@@ -64,16 +64,12 @@ def tf_test_object(is_mock, tf_dir, tmp_path, aws_provider_override):
             for tf_object in tf_objects:
                 aws_providers.extend(tf_aws_providers(tf_object))
 
-            # For all aws provider blocks that contain an "alias" attribute,
-            # add a mock aws provider config with that alias
-            for provider in aws_providers:
-                if "alias" in provider:
-                    mock_provider["provider"]["aws"].append(
-                        {
-                            **mock_aws_provider,
-                            **{"alias": provider["alias"]},
-                        }
-                    )
+            # Merge mock config into each discovered aws provider block so that
+            # any attributes present in the original (e.g. alias, region) are
+            # preserved while mock settings take precedence.
+            mock_provider["provider"]["aws"].extend(
+                {**provider, **mock_aws_provider} for provider in aws_providers
+            )
 
             tf_provider_path = Path(current_dir / MOCKSTACK_TF_PROVIDER_OVERRIDE)
             extra_files.append(


### PR DESCRIPTION
Previously, the mock provider injection only copied the `alias` attribute from discovered aws provider blocks, which was fragile and missed other attributes like `region`. Now, each discovered aws provider block is merged into the mock config (original attributes first, mock overrides second) and extended onto the default mock provider list, preserving all original attributes while ensuring mock settings take precedence.

This should fix the failing tests on the s3-bucket module, since the provider is now sending the region attribute to all resources, and we were not setting the region correctly on the mock provider.
* https://github.com/plus3it/terraform-aws-tardigrade-s3-bucket/actions/runs/24489420782/job/71571142792?pr=207